### PR TITLE
E911: Added AnsibleSyntaxCheckRule for running ansible syntax check

### DIFF
--- a/lib/ansiblelint/rules/AnsibleSyntaxCheckRule.py
+++ b/lib/ansiblelint/rules/AnsibleSyntaxCheckRule.py
@@ -1,0 +1,101 @@
+"""Rule definition for ansible syntax check."""
+import re
+import subprocess
+import sys
+from typing import List
+
+from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.text import strip_ansi_escape
+
+_ansible_syntax_check_re = re.compile(
+    r"^ERROR! (?P<title>[^\n]*)\n\nThe error appears to be in "
+    r"'(?P<filename>.*)': line (?P<line>\d+), column (?P<column>\d+)",
+    re.MULTILINE | re.S | re.DOTALL)
+
+
+class AnsibleSyntaxCheckRule(AnsibleLintRule):
+    """Ansible syntax check report failure."""
+
+    id = "911"
+    shortdesc = "Ansible syntax check failed"
+    description = "Running ansible-playbook --syntax-check ... reported an error."
+    severity = "VERY_HIGH"
+    tags = ["core"]
+    version_added = "v5.0.0"
+
+    @staticmethod
+    def _get_ansible_syntax_check_matches(lintable: Lintable) -> List[MatchError]:
+        """Run ansible syntax check and return a list of MatchError(s)."""
+        if lintable.kind != 'playbook':
+            return []
+
+        run = subprocess.run(
+            ['ansible-playbook', '--syntax-check', lintable.path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,  # needed when command is a list
+            universal_newlines=True,
+            check=False
+        )
+        result = []
+        if run.returncode != 0:
+            message = None
+            filename = None
+            linenumber = 0
+            column = None
+
+            stderr = strip_ansi_escape(run.stderr)
+            stdout = strip_ansi_escape(run.stdout)
+            if stderr:
+                details = stderr
+                if stdout:
+                    details += "\n" + stdout
+            else:
+                details = stdout
+
+            m = _ansible_syntax_check_re.search(stderr)
+            if m:
+                message = m.groupdict()['title']
+                # Ansible returns absolute paths
+                filename = m.groupdict()['filename']
+                linenumber = int(m.groupdict()['line'])
+                column = int(m.groupdict()['column'])
+
+            if run.returncode == 4:
+                rule: BaseRule = AnsibleSyntaxCheckRule()
+            else:
+                rule = RuntimeErrorRule()
+                if not message:
+                    message = (
+                        "Ansible --syntax-check reported unexpected "
+                        f"error code {run.returncode}")
+
+            result.append(MatchError(
+                message=message,
+                filename=filename,
+                linenumber=linenumber,
+                column=column,
+                rule=rule,
+                details=details
+                ))
+        return result
+
+
+# testing code to be loaded only with pytest or when executed the rule file
+if "pytest" in sys.modules:
+
+    def test_get_ansible_syntax_check_matches() -> None:
+        """Validate parsing of ansible output."""
+        lintable = Lintable('examples/playbooks/conflicting_action.yml', kind='playbook')
+        result = AnsibleSyntaxCheckRule._get_ansible_syntax_check_matches(lintable)
+        assert result[0].linenumber == 3
+        assert result[0].column == 7
+        assert result[0].message == "conflicting action statements: debug, command"
+        # We internaly convert absolute paths returned by ansible into paths
+        # relative to current directory.
+        assert result[0].filename.endswith("/conflicting_action.yml")
+        assert len(result) == 1

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -4,12 +4,12 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, FrozenSet, Generator, List, Optional, Set, Union
 
-import ansiblelint.file_utils
 import ansiblelint.skip_utils
 import ansiblelint.utils
 from ansiblelint._internal.rules import LoadingFailureRule
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
+from ansiblelint.rules.AnsibleSyntaxCheckRule import AnsibleSyntaxCheckRule
 
 if TYPE_CHECKING:
     from ansiblelint.rules import RulesCollection
@@ -77,29 +77,37 @@ class Runner(object):
     def run(self) -> List[MatchError]:
         """Execute the linting process."""
         files: List[Lintable] = list()
+        matches: List[MatchError] = list()
+
         for playbook in self.playbooks:
             if self.is_excluded(str(playbook.path.resolve())) or playbook.kind == 'role':
                 continue
             files.append(playbook)
-        matches = set(self._emit_matches(files))
+            matches.extend(AnsibleSyntaxCheckRule._get_ansible_syntax_check_matches(playbook))
 
-        # remove duplicates from files list
-        files = [value for n, value in enumerate(files) if value not in files[:n]]
+        if not matches:  # do our processing only when ansible syntax check passed
 
-        # remove files that have already been checked
-        files = [x for x in files if x.path not in self.checked_files]
-        for file in files:
-            _logger.debug(
-                "Examining %s of type %s",
-                ansiblelint.file_utils.normpath(file.path),
-                file.kind)
-            matches = matches.union(
-                self.rules.run(file, tags=set(self.tags),
-                               skip_list=self.skip_list))
+            matches.extend(self._emit_matches(files))
+
+            # remove duplicates from files list
+            files = [value for n, value in enumerate(files) if value not in files[:n]]
+
+            # remove files that have already been checked
+            files = [x for x in files if x.path not in self.checked_files]
+            for file in files:
+                _logger.debug(
+                    "Examining %s of type %s",
+                    ansiblelint.file_utils.normpath(file.path),
+                    file.kind)
+
+                matches.extend(
+                    self.rules.run(file, tags=set(self.tags),
+                                   skip_list=self.skip_list))
+
         # update list of checked files
         self.checked_files.update([str(x.path) for x in files])
 
-        return sorted(matches)
+        return sorted(list(set(matches)))
 
     def _emit_matches(self, files: List[Lintable]) -> Generator[MatchError, None, None]:
         visited: Set = set()

--- a/lib/ansiblelint/text.py
+++ b/lib/ansiblelint/text.py
@@ -1,0 +1,15 @@
+"""Text utils."""
+import re
+from typing import Union
+
+
+def strip_ansi_escape(data: Union[str, bytes]) -> str:
+    """Remove all ANSI escapes from string or bytes.
+
+    If bytes is passed instead of string, it will be converted to string
+    using UTF-8.
+    """
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+
+    return re.sub(r"\x1b[^m]*m", "", data)

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -12,4 +12,5 @@ def test_example_plain_string(default_rules_collection):
     """Validates that loading valid YAML string produce error."""
     result = Runner(default_rules_collection, 'examples/plain_string.yml', [], [], []).run()
     assert len(result) == 1
-    assert "Failed to load or parse file" in result[0].message
+    assert result[0].rule.id == "911"
+    assert "A playbook must be a list of plays" in result[0].message

--- a/test/TestImportIncludeRole.py
+++ b/test/TestImportIncludeRole.py
@@ -19,14 +19,6 @@ PLAY_IMPORT_ROLE = '''
         name: test-role
 '''
 
-PLAY_IMPORT_ROLE_INCOMPLETE = '''
-- hosts: all
-
-  tasks:
-    - import_role:
-        foo: bar
-'''
-
 PLAY_IMPORT_ROLE_INLINE = '''
 - hosts: all
 
@@ -84,19 +76,6 @@ def playbook_path(request, tmp_path):
                  ),
 ), indirect=('playbook_path', ))
 def test_import_role2(default_rules_collection, playbook_path, messages):
-    runner = Runner(default_rules_collection, playbook_path, [], [], [])
-    results = runner.run()
-    for message in messages:
-        assert message in str(results)
-
-
-@pytest.mark.parametrize(('playbook_path', 'messages'), (
-    pytest.param(PLAY_IMPORT_ROLE_INCOMPLETE,
-                 ["Failed to find required 'name' key in import_role"],
-                 id='IMPORT_ROLE_INCOMPLETE',
-                 ),
-), indirect=('playbook_path', ))
-def test_invalid_import_role(default_rules_collection, playbook_path, messages):
     runner = Runner(default_rules_collection, playbook_path, [], [], [])
     results = runner.run()
     for message in messages:

--- a/test/TestImportWithMalformed.py
+++ b/test/TestImportWithMalformed.py
@@ -2,15 +2,16 @@ import pytest
 
 from ansiblelint.file_utils import Lintable
 
-IMPORT_TASKS_MAIN = Lintable('import-tasks-main.yml', '''
+IMPORT_TASKS_MAIN = Lintable('import-tasks-main.yml', '''\
 - oops this is invalid
 ''')
 
-IMPORT_SHELL_PIP = Lintable('import-tasks-main.yml', '''
+IMPORT_SHELL_PIP = Lintable('import-tasks-main.yml', '''\
 - shell: pip
+  changed: false
 ''')
 
-PLAY_IMPORT_TASKS = Lintable('playbook.yml', '''
+PLAY_IMPORT_TASKS = Lintable('playbook.yml', '''\
 - hosts: all
   tasks:
     - import_tasks: import-tasks-main.yml
@@ -24,17 +25,13 @@ PLAY_IMPORT_TASKS = Lintable('playbook.yml', '''
         pytest.param(
             [IMPORT_TASKS_MAIN, PLAY_IMPORT_TASKS],
             id='import_tasks w/ malformed import',
-            marks=pytest.mark.xfail(
-                reason='Garbage non-tasks sequence is not being '
-                'properly processed. Ref: '
-                'https://github.com/ansible-community/ansible-lint/issues/707',
-                raises=AttributeError,
-            ),
         ),
     ),
     indirect=['_play_files']
 )
 @pytest.mark.usefixtures('_play_files')
 def test_import_tasks_with_malformed_import(runner):
-    results = str(runner.run())
-    assert 'only when shell functionality is required' in results
+    results = runner.run()
+    assert len(results) == 1
+    assert results[0].rule.id == '911'
+    assert results[0].rule.shortdesc == 'Ansible syntax check failed'


### PR DESCRIPTION
Fixes issue where passing task/var files to the linter would return false-positives. 
The linter reported the task files as playbooks but silently failed to lint them and passed.

From now, any argument that is not of playbook type will generate specific errors caused by ansible syntax-check fails.

This does affect performance, especially during our own testing, but the real benefit is that we now get confirmation from Ansible itself. We can look into improving performance in follow-ups if we find a way to instantiate ansible runtime only once instead of running the CLI tool every time. Still this comes with downsides too because the CLI interface is more stable. Another possible path to improve performance would be to run the syntax check async on multiple threads. Anyway, any approach will in **follow-up**, not as part of this initial implementation.

Fixes: #787