### PR TITLE
Make coverage report run only on full test runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,12 +14,6 @@ addopts =
     --doctest-modules
     --junitxml=.test-results/pytest/results.xml
 
-    # `pytest-cov`:
-    --cov=ansiblelint
-    --cov-report term-missing:skip-covered
-    --cov-report xml:.test-results/pytest/cov.xml
-    --no-cov-on-fail
-
     # interpret all the target args as importables:
     --pyargs
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,10 +25,16 @@ deps =
 commands =
   # safety measure to assure we do not accidentaly run tests with broken dependencies
   {envpython} -m pip check
+  # We add coverage options but not making them mandatory as we do not want to force
+  # pytest users to run coverage when they just want to run a single test with `pytest -k test`
   {envpython} -m pytest \
-  --cov "{envsitepackagesdir}/ansiblelint" \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
-  {posargs:}
+  {posargs:\
+    --cov ansiblelint \
+    --cov "{envsitepackagesdir}/ansiblelint" \
+    --cov-report term-missing:skip-covered \
+    --cov-report xml:.test-results/pytest/cov.xml \
+    --no-cov-on-fail}
 install_command =
   {envpython} -m \
     pip install \
@@ -37,6 +43,7 @@ install_command =
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
   HOME
+  PYTEST_*  # allows developer to define their own preferences
   REQUESTS_CA_BUNDLE  # https proxies
   SSL_CERT_FILE  # https proxies
 # recreate = True


### PR DESCRIPTION
We add coverage options but not making them mandatory as we do not want to force pytest users to run coverage when they just want to run a single test with `pytest -k test`.

Settings added to repository pytest.ini become defaults for all executions.