### PR TITLE
Replace ruamel.yaml with ruyaml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,9 +73,7 @@ install_requires =
   ansible >= 2.8
   pyyaml
   rich
-  ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
-  ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
-  # NOTE: per issue #509 0.15.34 included in debian backports
+  ruyaml >= 0.19,<1
   typing-extensions; python_version < "3.8"
 
 [options.entry_points]


### PR DESCRIPTION
Replace dependency of ruamel.yaml with ruyaml fork. Apparently ruamel.yaml maintenance followed a serious of questionable practices like move of project code, not following packaging guidelines and in the end censorship of tickets (blocked access).

Note that currently `ruyaml` package installs `ruamel.yaml` module, which makes it incompatible with former library. This will likely be fixed in next version which will use a separated namespace to avoid conflict.

Related: https://github.com/pycontribs/ruyaml/issues/1