### PR TITLE
Reduce ansible dependency a little bit

### DIFF
--- a/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -21,19 +21,7 @@
 import os
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import get_first_cmd_arg
-
-try:
-    from ansible.module_utils.parsing.convert_bool import boolean
-except ImportError:
-    try:
-        from ansible.utils.boolean import boolean
-    except ImportError:
-        try:
-            from ansible.utils import boolean
-        except ImportError:
-            from ansible import constants
-            boolean = constants.mk_boolean
+from ansiblelint.utils import convert_to_boolean, get_first_cmd_arg
 
 
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
@@ -60,6 +48,6 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
 
             executable = os.path.basename(first_cmd_arg)
             if executable in self._arguments and \
-                    boolean(task['action'].get('warn', True)):
+                    convert_to_boolean(task['action'].get('warn', True)):
                 message = "{0} used in place of argument {1} to file module"
                 return message.format(executable, self._arguments[executable])

--- a/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/lib/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -21,19 +21,7 @@
 import os
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import get_first_cmd_arg
-
-try:
-    from ansible.module_utils.parsing.convert_bool import boolean
-except ImportError:
-    try:
-        from ansible.utils.boolean import boolean
-    except ImportError:
-        try:
-            from ansible.utils import boolean
-        except ImportError:
-            from ansible import constants
-            boolean = constants.mk_boolean
+from ansiblelint.utils import convert_to_boolean, get_first_cmd_arg
 
 
 class CommandsInsteadOfModulesRule(AnsibleLintRule):
@@ -81,6 +69,6 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
 
         executable = os.path.basename(first_cmd_arg)
         if executable in self._modules and \
-                boolean(task['action'].get('warn', True)):
+                convert_to_boolean(task['action'].get('warn', True)):
             message = '{0} used in place of {1} module'
             return message.format(executable, self._modules[executable])

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -29,7 +29,7 @@ from argparse import Namespace
 from collections import OrderedDict
 from functools import lru_cache
 from pathlib import Path
-from typing import Callable, ItemsView, List, Optional, Tuple
+from typing import Any, Callable, ItemsView, List, Optional, Tuple
 
 import yaml
 from ansible import constants
@@ -50,6 +50,18 @@ from ansiblelint.constants import (
 )
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import normpath
+
+try:
+    from ansible.module_utils.parsing.convert_bool import boolean
+except ImportError:
+    try:
+        from ansible.utils.boolean import boolean
+    except ImportError:
+        try:
+            from ansible.utils import boolean
+        except ImportError:
+            from ansible import constants
+            boolean = constants.mk_boolean
 
 # ansible-lint doesn't need/want to know about encrypted secrets, so we pass a
 # string as the password to enable such yaml files to be opened and parsed
@@ -834,3 +846,8 @@ def get_rules_dirs(rulesdir: List[str], use_default: bool) -> List[str]:
         return rulesdir + custom_ruledirs + default_ruledirs
 
     return rulesdir or custom_ruledirs + default_ruledirs
+
+
+def convert_to_boolean(value: Any) -> bool:
+    """Use Ansible to convert something to a boolean."""
+    return boolean(value)

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -52,7 +52,6 @@ except ImportError:
         try:
             from ansible.utils import boolean
         except ImportError:
-            from ansible import constants
             boolean = constants.mk_boolean
 
 from yaml.composer import Composer

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -42,14 +42,6 @@ from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.parsing.yaml.objects import AnsibleSequence
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.template import Templar
-from yaml.composer import Composer
-from yaml.representer import RepresenterError
-
-from ansiblelint.constants import (
-    ANSIBLE_FAILURE_RC, CUSTOM_RULESDIR_ENVVAR, DEFAULT_RULESDIR, FileType,
-)
-from ansiblelint.errors import MatchError
-from ansiblelint.file_utils import normpath
 
 try:
     from ansible.module_utils.parsing.convert_bool import boolean
@@ -62,6 +54,15 @@ except ImportError:
         except ImportError:
             from ansible import constants
             boolean = constants.mk_boolean
+
+from yaml.composer import Composer
+from yaml.representer import RepresenterError
+
+from ansiblelint.constants import (
+    ANSIBLE_FAILURE_RC, CUSTOM_RULESDIR_ENVVAR, DEFAULT_RULESDIR, FileType,
+)
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import normpath
 
 # ansible-lint doesn't need/want to know about encrypted secrets, so we pass a
 # string as the password to enable such yaml files to be opened and parsed


### PR DESCRIPTION
~~This is causing so much pain, let's get rid of it. Obviously we still need the `ansible` Python lib, but the user can provide that also by installing `ansible-base` instead of Ansible.~~

This has mostly been done by @ssbarnea already, I reduced this PR to the part that still makes sense.