### PR TITLE
Refactor ANSI implementation

### DIFF
--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -3,8 +3,6 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Generic, TypeVar, Union
 
-from ansiblelint.color import Color, colorize
-
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
 
@@ -44,59 +42,34 @@ class BaseFormatter(Generic[T]):
         # Use os.path.relpath 'cause Path.relative_to() misbehaves
         return os.path.relpath(path, start=self._base_dir)
 
-    def format(self, match: "MatchError", colored: bool = False) -> str:
+    def format(self, match: "MatchError") -> str:
         return str(match)
 
 
 class Formatter(BaseFormatter):
 
-    def format(self, match: "MatchError", colored: bool = False) -> str:
-        formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
+    def format(self, match: "MatchError") -> str:
         _id = getattr(match.rule, 'id', '000')
-        if colored:
-            return formatstr.format(
-                colorize(u"[{0}]".format(_id), Color.error_code),
-                colorize(match.message, Color.error_title),
-                colorize(self._format_path(match.filename or ""), Color.filename),
-                colorize(str(match.linenumber), Color.linenumber),
-                colorize(u"{0}".format(match.details), Color.line))
-        else:
-            return formatstr.format(_id,
-                                    match.message,
-                                    match.filename or "",
-                                    match.linenumber,
-                                    match.details)
+        return (
+            f"[error_code]{_id}[/] [error_title]{match.message}[/]\n"
+            f"[filename]{self._format_path(match.filename or '')}[/]:{match.linenumber}\n"
+            f"[dim]{match.details}[/]\n")
 
 
 class QuietFormatter(BaseFormatter):
 
-    def format(self, match: "MatchError", colored: bool = False) -> str:
-        formatstr = u"{0} {1}:{2}"
-        if colored:
-            return formatstr.format(
-                colorize(u"[{0}]".format(match.rule.id), Color.error_code),
-                colorize(self._format_path(match.filename or ""), Color.filename),
-                colorize(str(match.linenumber), Color.linenumber))
-        else:
-            return formatstr.format(match.rule.id, self._format_path(match.filename or ""),
-                                    match.linenumber)
+    def format(self, match: "MatchError") -> str:
+        return (
+            f"[error_code]{match.rule.id}[/] "
+            f"[filename]{self._format_path(match.filename or '')}[/]:{match.linenumber}")
 
 
 class ParseableFormatter(BaseFormatter):
 
-    def format(self, match: "MatchError", colored: bool = False) -> str:
-        formatstr = u"{0}:{1}: [{2}] {3}"
-        if colored:
-            return formatstr.format(
-                colorize(self._format_path(match.filename or ""), Color.filename),
-                colorize(str(match.linenumber), Color.linenumber),
-                colorize(u"E{0}".format(match.rule.id), Color.error_code),
-                colorize(u"{0}".format(match.message), Color.error_title))
-        else:
-            return formatstr.format(self._format_path(match.filename or ""),
-                                    match.linenumber,
-                                    "E" + match.rule.id,
-                                    match.message)
+    def format(self, match: "MatchError") -> str:
+        return (
+            f"[filename]{self._format_path(match.filename or '')}[/]:{match.linenumber}: "
+            f"[[error_code]E{match.rule.id}[/]] [dim]{match.message}[/]")
 
 
 class AnnotationsFormatter(BaseFormatter):
@@ -114,11 +87,8 @@ class AnnotationsFormatter(BaseFormatter):
     Supported levels: debug, warning, error
     """
 
-    def format(self, match: "MatchError", colored: bool = False) -> str:
+    def format(self, match: "MatchError") -> str:
         """Prepare a match instance for reporting as a GitHub Actions annotation."""
-        if colored:
-            raise ValueError('The colored mode is not supported.')
-
         level = self._severity_to_level(match.rule.severity)
         file_path = self._format_path(match.filename or "")
         line_num = match.linenumber
@@ -142,8 +112,7 @@ class AnnotationsFormatter(BaseFormatter):
 
 class ParseableSeverityFormatter(BaseFormatter):
 
-    def format(self, match: "MatchError", colored: bool = False) -> str:
-        formatstr = u"{0}:{1}: [{2}] [{3}] {4}"
+    def format(self, match: "MatchError") -> str:
 
         filename = self._format_path(match.filename or "")
         linenumber = str(match.linenumber)
@@ -151,17 +120,6 @@ class ParseableSeverityFormatter(BaseFormatter):
         severity = match.rule.severity
         message = str(match.message)
 
-        if colored:
-            filename = colorize(filename, Color.filename)
-            linenumber = colorize(linenumber, Color.linenumber)
-            rule_id = colorize(rule_id, Color.error_code)
-            severity = colorize(severity, Color.error_code)
-            message = colorize(message, Color.error_title)
-
-        return formatstr.format(
-            filename,
-            linenumber,
-            rule_id,
-            severity,
-            message,
-        )
+        return (
+            f"[filename]{filename}[/]:{linenumber}: [[error_code]{rule_id}[/]] "
+            f"[[error_code]{severity}[/]] [dim]{message}[/]")

--- a/test/TestFormatter.py
+++ b/test/TestFormatter.py
@@ -31,16 +31,31 @@ class TestFormatter(unittest.TestCase):
     def setUp(self):
         self.rule = AnsibleLintRule()
         self.rule.id = "TCF0001"
-        self.formatter = Formatter(pathlib.Path.cwd(), True)
+        self.formatter = Formatter(pathlib.Path.cwd(), display_relative_path=True)
 
     def test_format_coloured_string(self):
-        match = MatchError("message", 1, "hello", "filename.yml", self.rule)
-        self.formatter.format(match, True)
+        match = MatchError(
+            message="message",
+            linenumber=1,
+            details="hello",
+            filename="filename.yml",
+            rule=self.rule)
+        self.formatter.format(match)
 
     def test_unicode_format_string(self):
-        match = MatchError(u'\U0001f427', 1, "hello", "filename.yml", self.rule)
-        self.formatter.format(match, False)
+        match = MatchError(
+            message=u'\U0001f427',
+            linenumber=1,
+            details="hello",
+            filename="filename.yml",
+            rule=self.rule)
+        self.formatter.format(match)
 
     def test_dict_format_line(self):
-        match = MatchError("xyz", 1, {'hello': 'world'}, "filename.yml", self.rule,)
-        self.formatter.format(match, True)
+        match = MatchError(
+            message="xyz",
+            linenumber=1,
+            details={'hello': 'world'},
+            filename="filename.yml",
+            rule=self.rule,)
+        self.formatter.format(match)

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -45,25 +45,22 @@ def test_runner(default_rules_collection, playbook, exclude, length):
     assert len(matches) == length
 
 
-@pytest.mark.parametrize(('formatter_cls', 'format_kwargs'), (
-    pytest.param(formatters.Formatter, {}, id='Formatter-plain'),
+@pytest.mark.parametrize(('formatter_cls'), (
+    pytest.param(formatters.Formatter, id='Formatter-plain'),
     pytest.param(formatters.ParseableFormatter,
-                 {'colored': True},
                  id='ParseableFormatter-colored'),
     pytest.param(formatters.QuietFormatter,
-                 {'colored': True},
                  id='QuietFormatter-colored'),
     pytest.param(formatters.Formatter,
-                 {'colored': True},
                  id='Formatter-colored'),
 ))
-def test_runner_unicode_format(default_rules_collection, formatter_cls, format_kwargs):
-    formatter = formatter_cls(os.getcwd(), True)
+def test_runner_unicode_format(default_rules_collection, formatter_cls):
+    formatter = formatter_cls(os.getcwd(), display_relative_path=True)
     runner = Runner(default_rules_collection, 'test/unicode.yml', [], [], [])
 
     matches = runner.run()
 
-    formatter.format(matches[0], **format_kwargs)
+    formatter.format(matches[0])
 
 
 @pytest.mark.parametrize('directory_name', ('test/', os.path.abspath('test')))


### PR DESCRIPTION
* Replace internal colorize() method with rich own one. This makes the our code much cleaner and easier to maintain.
* Disabling emoji support is needed because otherwise `file:100:` would become an `file`:100: emoji.
* Now "rich" is imported only from inside color module, making easier to refactor
* Assured that command line overrides for coloring do reconfigure consoles
* Make YAML output easier to read and consistent.

Example after:

![](https://sbarnea.com/ss/Screen-Shot-2020-12-23-13-11-55.16.png)
![](https://sbarnea.com/ss/Screen-Shot-2020-12-23-13-12-55.36.png)
