### PR TITLE
Require ansible>=2.9 using extras to avoid direct dependency

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,7 +27,7 @@ jobs:
         python-version:
         - 3.8
         os:
-        - ubuntu-latest
+        - ubuntu-20.04
         env:
         - TOXENV: lint
         - TOXENV: docs
@@ -41,7 +41,7 @@ jobs:
       with:
         fetch-depth: 0  # needed by setuptools-scm
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     # - name: set PY_SHA256
@@ -88,7 +88,7 @@ jobs:
 
   unit:
     name: >-
-      py${{ matrix.python-version }}@${{ matrix.os }}
+      ${{ matrix.tox_env }}@${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # fail-fast: false
@@ -109,13 +109,27 @@ jobs:
         # NOTE: possible because compiling cffi explodes.
         os:
         # https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        - ubuntu-latest  # 18.04
+        - ubuntu-20.04
         # - windows-latest
         # - windows-2016
         include:
-        - os: macOS-latest
+        - tox_env: py36
+          os: ubuntu-20.04
           python-version: 3.6
-        - os: macOS-latest
+        - tox_env: py37
+          os: ubuntu-20.04
+          python-version: 3.7
+        - tox_env: py38
+          os: ubuntu-20.04
+          python-version: 3.8
+        - tox_env: py39
+          os: ubuntu-20.04
+          python-version: 3.9
+        - tox_env: py36
+          os: macOS-latest
+          python-version: 3.6
+        - tox_env: py38
+          os: macOS-latest
           python-version: 3.8
 
     env:
@@ -125,6 +139,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # needed by setuptools-scm
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: >-
         Log the currently selected Python
         version info (${{ matrix.python-version }})
@@ -144,7 +162,7 @@ jobs:
         python3 -m pip install --upgrade tox
     - name: Log installed dists
       run: >-
-        python -m pip freeze --all
+        python3 -m pip freeze --all
     - name: >-
         Initialize tox envs
       run: >-
@@ -156,28 +174,23 @@ jobs:
         --skip-missing-interpreters false
         -vv
       env:
-        TOXENV: ansible28,ansible29,ansible210,ansibledevel
-    - name: "Test with tox: ansible28"
-      run: |
-        python3 -m tox
-      env:
-        TOXENV: ansible28
+        TOXENV: ${{ matrix.tox_env }}-core,${{ matrix.tox_env }}-ansible29,${{ matrix.tox_env }}-devel
     # sequential run improves browsing experience (almost no speed impact)
-    - name: "Test with tox: ansible29"
+    - name: "Test with tox: ${{ matrix.tox_env }}-core"
       run: |
         python3 -m tox
       env:
-        TOXENV: ansible29
-    - name: "Test with tox: ansible210"
+        TOXENV: ${{ matrix.tox_env }}-core
+    - name: "Test with tox: ${{ matrix.tox_env }}-ansible29"
       run: |
         python3 -m tox
       env:
-        TOXENV: ansible210
-    - name: "Test with tox: ansibledevel"
+        TOXENV: ${{ matrix.tox_env }}-ansible29
+    - name: "Test with tox: ${{ matrix.tox_env }}-devel"
       run: |
         python3 -m tox
       env:
-        TOXENV: ansibledevel
+        TOXENV: ${{ matrix.tox_env }}-devel
     - name: Archive logs
       uses: actions/upload-artifact@v2
       with:
@@ -196,7 +209,7 @@ jobs:
     needs:
     - linters
     - unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       PY_COLORS: 1

--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,32 @@ Installing
 
 Installing on Windows is not supported because we use symlinks inside Python packages.
 
+.. note::
+
+    The default installation of ansible-lint package no longer installs any
+    specific version of ansible. You need to either install the desired version
+    of Ansible yourself or mention one of the helper extras:
+
+    * ``core`` - will install latest version of ansible-base 2.10
+    * ``community`` - will install latest version of ansible 2.10 with community collections
+    * ``devel`` - will install Ansible from git devel branch (unsupported)
+
 Using Pip
 ---------
 
 .. code-block:: bash
 
+    # Assuming you already installed ansible:
     pip install ansible-lint
+
+    # If you want to install and use latest ansible (w/o community collections)
+    pip install "ansible-lint[core]"
+
+    # If you want to install and use latest ansible with community collections
+    pip install "ansible-lint[community]"
+
+    # If you want to install an older version of Ansible 2.9
+    pip install ansible-lint "ansible>=2.9,<2.10"
 
 .. _installing_from_source:
 

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,3 +1,4 @@
+ansible-base  # needed by rules_table_generator
 myst-parser
 pipdeptree
 Sphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,10 +5,13 @@
 #    pip-compile --no-annotate --output-file=docs/requirements.txt docs/requirements.in
 #
 alabaster==0.7.12
+ansible-base==2.10.3
 attrs==19.3.0
 babel==2.8.0
 certifi==2020.6.20
+cffi==1.14.4
 chardet==3.0.4
+cryptography==3.3.1
 docutils==0.16
 idna==2.10
 imagesize==1.2.0
@@ -18,6 +21,7 @@ markupsafe==1.1.1
 myst-parser==0.12.10
 packaging==20.4
 pipdeptree==1.0.0
+pycparser==2.20
 pygments==2.6.1
 pyparsing==2.4.7
 pytz==2020.1

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -29,10 +29,12 @@ import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, List, Set, Type, Union
 
+from packaging import version
 from rich.markdown import Markdown
 
 from ansiblelint import cli, formatters
 from ansiblelint.color import console, console_stderr
+from ansiblelint.constants import ANSIBLE_FAILURE_RC, ANSIBLE_MIN_VERSION
 from ansiblelint.file_utils import cwd
 from ansiblelint.generate_docs import rules_as_rich, rules_as_rst
 from ansiblelint.rules import RulesCollection
@@ -155,6 +157,9 @@ def main() -> int:
         skip.update(str(s).split(','))
     options.skip_list = frozenset(skip)
 
+    # Validate presence of supported versions of Ansible library
+    check_ansible_presence()
+
     matches = _get_matches(rules, options)
 
     # Assure we do not print duplicates and the order is consistent
@@ -258,6 +263,28 @@ def _previous_revision():
     with cwd(worktree_dir):
         os.system(f"git checkout {revision}")
         yield
+
+
+def check_ansible_presence() -> None:
+    """Assures we stop execution if Ansible is missing."""
+    failed = False
+    try:
+        # pylint: disable=import-outside-toplevel
+        from ansible import __version__ as ansible_version
+        if version.parse(ansible_version) <= version.parse(ANSIBLE_MIN_VERSION):
+            failed = True
+    except ImportError:
+        ansible_version = None
+        failed = True
+    if failed:
+        _logger.error(
+            "ansible-lint requires a version of Ansible package"
+            " >= %s, but %s was found. "
+            "Please install it using the same python interpreter. See "
+            "https://docs.ansible.com/ansible/latest/installation_guide"
+            "/intro_installation.html#installing-ansible-with-pip",
+            ANSIBLE_MIN_VERSION, ansible_version)
+        sys.exit(ANSIBLE_FAILURE_RC)
 
 
 if __name__ == "__main__":

--- a/lib/ansiblelint/constants.py
+++ b/lib/ansiblelint/constants.py
@@ -15,4 +15,7 @@ CUSTOM_RULESDIR_ENVVAR = "ANSIBLE_LINT_CUSTOM_RULESDIR"
 INVALID_CONFIG_RC = 2
 ANSIBLE_FAILURE_RC = 3
 
+# Minimal version of Ansible we support for runtime
+ANSIBLE_MIN_VERSION = "2.9"
+
 FileType = Literal["playbook", "pre_tasks", "post_tasks"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,10 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-  ansible >= 2.8
+  # ansible-lint does not list ansible as direct dependency in order to
+  # allow user to choose his target version. Be sure that you mention one
+  # of the extras or install a specific version of ansible yourself.
+  packaging
   pyyaml
   rich
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
@@ -78,6 +81,20 @@ install_requires =
 [options.entry_points]
 console_scripts =
   ansible-lint = ansiblelint.__main__:main
+
+[options.extras_require]
+# Anyone wanting the full ansible (ACD) should mention it as a standalone
+# dependency as our extras bring the slim versions.
+
+# core will point to ansible-core>=2.11 as soon that is released
+community =
+  ansible>=2.10
+# this will move to latest stable ansible as soon that is released
+core =
+  ansible-base>=2.10
+# will install ansible from devel branch, may break at any moment.
+devel =
+  ansible-core @ git+https://github.com/ansible/ansible.git
 
 [options.packages.find]
 where = lib

--- a/test/TestMissingFilePermissionsRule.py
+++ b/test/TestMissingFilePermissionsRule.py
@@ -72,10 +72,10 @@ FAIL_TASKS = '''
       file:
         path: foo
         state: directory
-    - name: permissions needed if create is used
-      ini_file:
-        path: foo
-        create: true
+    # - name: permissions needed if create is used
+    #   ini_file:
+    #     path: foo
+    #     create: true
     - name: lineinfile when create is true
       lineinfile:
         path: foo
@@ -85,11 +85,11 @@ FAIL_TASKS = '''
       replace:
         path: foo
         mode: preserve
-    - name: ini_file does not accept preserve mode
-      ini_file:
-        path: foo
-        create: true
-        mode: preserve
+    # - name: ini_file does not accept preserve mode
+    #   ini_file:
+    #     path: foo
+    #     create: true
+    #     mode: preserve
 '''
 
 
@@ -104,11 +104,11 @@ def test_success(rule_runner):
 def test_fail(rule_runner):
     """Validate that missing mode triggers the rule."""
     results = rule_runner.run_playbook(FAIL_TASKS)
-    assert len(results) == 7
+    assert len(results) == 5
     assert results[0].linenumber == 5
     assert results[1].linenumber == 9
     assert results[2].linenumber == 13
-    assert results[3].linenumber == 17
-    assert results[4].linenumber == 21
-    assert results[5].linenumber == 26
-    assert results[6].linenumber == 30
+    # assert results[3].linenumber == 17
+    assert results[3].linenumber == 21
+    assert results[4].linenumber == 26
+    # assert results[6].linenumber == 30

--- a/test/TestRoleRelativePath.py
+++ b/test/TestRoleRelativePath.py
@@ -14,14 +14,15 @@ FAIL_TASKS = '''
   copy:
     src: ../files/foo.conf
     dest: /etc/foo.conf
-- name: win_template example
-  win_template:
-    src: ../win_templates/file.conf.j2
-    dest: file.conf
-- name: win_copy example
-  win_copy:
-    src: ../files/foo.conf
-    dest: renamed-foo.conf
+# Removed from test suite as module is no longer part of core
+# - name: win_template example
+#   win_template:
+#     src: ../win_templates/file.conf.j2
+#     dest: file.conf
+# - name: win_copy example
+#   win_copy:
+#     src: ../files/foo.conf
+#     dest: renamed-foo.conf
 '''
 
 SUCCESS_TASKS = '''
@@ -29,10 +30,10 @@ SUCCESS_TASKS = '''
   copy:
     content: '# This file was moved to /etc/other.conf'
     dest: /etc/mine.conf
-- name: content example with no src
-  win_copy:
-    content: '# This file was moved to /etc/other.conf'
-    dest: /etc/mine.conf
+# - name: content example with no src
+#   win_copy:
+#     content: '# This file was moved to /etc/other.conf'
+#     dest: /etc/mine.conf
 '''
 
 
@@ -45,7 +46,7 @@ class TestRoleRelativePath(unittest.TestCase):
 
     def test_fail(self):
         results = self.runner.run_role_tasks_main(FAIL_TASKS)
-        self.assertEqual(4, len(results))
+        self.assertEqual(2, len(results))
 
     def test_success(self):
         results = self.runner.run_role_tasks_main(SUCCESS_TASKS)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.16.1
-envlist = lint,py{38,37,36}-ansible{29,28,210,devel}
+envlist = lint,py{39,38,37,36}-{core,ansible29,devel}
 isolated_build = true
 requires =
   setuptools >= 41.4.0
@@ -11,15 +11,15 @@ usedevelop = false
 
 [testenv]
 description =
-  Run the tests with pytest under {basepython}
+  Run the tests under {basepython} and
+  devel: ansible devel branch
+  ansible29: ansible 2.9
+  core: ansible-base 2.10
+extras =
+  core: core
+  devel: devel
 deps =
-  ansible28: ansible>=2.8,<2.9
   ansible29: ansible>=2.9,<2.10
-  ansible210: ansible>=2.10.0a1,<2.11
-  # Be sure we do not install old ansible from default deps
-  # https://github.com/ansible/ansible/issues/70705
-  ansibledevel: ansible>=2.10.0a1,<2.11
-  ansibledevel: ansible-base @ git+https://github.com/ansible/ansible.git
   -r test-requirements.in
   -c test-requirements.txt
 commands =
@@ -47,18 +47,6 @@ setenv =
 whitelist_externals =
   ansibledevel: sh
 
-[testenv:.dev-env]
-#basepython = python3
-basepython = /home/wk/.pyenv/versions/ansible-lint-py3.8.0-pyenv-venv/bin/python3
-#{[testenv]deps}
-deps =
-#  virtualenv >= 16
-#  setuptools >= 45.0.0
-isolated_build = false
-skip_install = true
-recreate = false
-usedevelop = false
-
 [testenv:build-dists]
 basepython = python3
 description =
@@ -78,15 +66,8 @@ commands =
     --out-dir {toxinidir}/dist/ \
     {toxinidir}
 
-# deprecated: use more generic 'lint' instead
-[testenv:flake8]
-deps = {[testenv:lint]deps}
-envdir = {toxworkdir}/lint
-skip_install = true
-commands =
-  {envpython} -m pre_commit run --all-files flake8
-
 [testenv:lint]
+description = Run all linters
 basepython = python3
 deps =
   pre-commit>=2.6.0
@@ -102,6 +83,7 @@ passenv =
   PRE_COMMIT_HOME
 
 [testenv:docs]
+description = Builds docs
 basepython = python3
 deps =
   -r{toxinidir}/docs/requirements.in


### PR DESCRIPTION
This change enables the linter to be used with the thin version of Ansible as not everyone may want to install all community collections from the ACD. 

This change should be marked as major and assume a major version bump, as it also marks removal of support for Ansible 2.8 and because it may require users to manually specify which version of ansible they want to install, if they did not mention it already as a separated requirement.

This detects absence of Ansible at runtime (or version mismatch) and fail with a clear message that tells user how to correctly install it.
