### PR TITLE
WIP: Change AnsibleLintRule.match signature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -565,8 +565,13 @@ A less-preferred method of skipping is to skip all task-based rules for a task (
       tags:
       - skip_ansible_lint
 
+
 Creating Custom Rules
 ---------------------
+
+TODO: Move the docs outside project readme and make the examples be
+included from source files, so we can test them and avoid having
+broken examples.
 
 Rules are described using a class file per rule. Default rules are named *DeprecatedVariableRule.py*, etc.
 
@@ -595,8 +600,11 @@ An example rule using ``match`` is:
                       'declarations'
         tags = { 'deprecations' }
 
-        def match(self, file, line):
-            return '${' in line
+        def match(self, file: "TargetFile", line: str = "") -> List[MatchError]:
+            result = []
+            if '${' in line:
+              result.append(self.create_matcherror())
+            return result
 
 An example rule using ``matchtask`` is:
 

--- a/lib/ansiblelint/_internal/rules.py
+++ b/lib/ansiblelint/_internal/rules.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
+    from ansiblelint.file_utils import TargetFile
 
 
 class BaseRule:
@@ -13,19 +14,22 @@ class BaseRule:
     description: str = ""
     version_added: str = ""
     severity: str = ""
-    match = None
     matchtask = None
     matchplay = None
 
-    def matchlines(self, file, text) -> List["MatchError"]:
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List["MatchError"]:
+        """Return matches found for a specific line with line_no."""
+        return []
+
+    def matchlines(self, file: "TargetFile", text: str) -> List["MatchError"]:
         """Return matches found for a specific line."""
         return []
 
-    def matchtasks(self, file: str, text: str) -> List["MatchError"]:
+    def matchtasks(self, file: "TargetFile", text: str) -> List["MatchError"]:
         """Return matches for a tasks file."""
         return []
 
-    def matchyaml(self, file: str, text: str) -> List["MatchError"]:
+    def matchyaml(self, file: "TargetFile", text: str) -> List["MatchError"]:
         """Return matches found for a specific YAML text."""
         return []
 

--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -1,9 +1,19 @@
 """Utility functions related to file operations."""
 import os
+import sys
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from pathlib import Path
+# idiom: https://github.com/python/typeshed/issues/3500#issuecomment-560958608
+if sys.version_info >= (3, 8):
+    from typing import TypedDict  # pylint: disable=no-name-in-module,ungrouped-imports
+else:
+    from typing_extensions import TypedDict
 
 
-def normpath(path) -> str:
+def normpath(path: Union[str, "Path"]) -> str:
     """
     Normalize a path in order to provide a more consistent output.
 
@@ -23,3 +33,14 @@ def cwd(path):
         yield
     finally:
         os.chdir(old_pwd)
+
+
+TargetFile = TypedDict(
+    "TargetFile",
+    {
+        'path': str,
+        'type': str,  # TODO: check for FileType
+        'absolute_directory': Optional[str]
+    },
+    total=False)
+"""TargetFile identifies a file or path to be linted."""

--- a/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/lib/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -2,8 +2,13 @@
 # Copyright (c) 2018, Ansible Project
 
 import re
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class ComparisonToEmptyStringRule(AnsibleLintRule):
@@ -19,5 +24,8 @@ class ComparisonToEmptyStringRule(AnsibleLintRule):
 
     empty_string_compare = re.compile("[=!]= ?(\"{2}|'{2})")
 
-    def match(self, file, line):
-        return self.empty_string_compare.search(line)
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List["MatchError"]:
+        result = []
+        if self.empty_string_compare.search(line):
+            result.append(MatchError(filename=file['path'], details=line, rule=self.__class__))
+        return result

--- a/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/lib/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -2,8 +2,13 @@
 # Copyright (c) 2018, Ansible Project
 
 import re
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class ComparisonToLiteralBoolRule(AnsibleLintRule):
@@ -19,5 +24,7 @@ class ComparisonToLiteralBoolRule(AnsibleLintRule):
 
     literal_bool_compare = re.compile("[=!]= ?(True|true|False|false)")
 
-    def match(self, file, line):
-        return self.literal_bool_compare.search(line)
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List["MatchError"]:
+        if self.literal_bool_compare.search(line):
+            return [MatchError(rule=self.__class__)]
+        return []

--- a/lib/ansiblelint/rules/LineTooLongRule.py
+++ b/lib/ansiblelint/rules/LineTooLongRule.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class LineTooLongRule(AnsibleLintRule):
@@ -15,5 +20,10 @@ class LineTooLongRule(AnsibleLintRule):
     tags = ['formatting']
     version_added = 'v4.0.0'
 
-    def match(self, file, line):
-        return len(line) > 160
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List["MatchError"]:
+        if len(line) > 160:
+            return [MatchError(
+                filename=file['path'],
+                details=line,
+                rule=self.__class__)]
+        return []

--- a/lib/ansiblelint/rules/NoTabsRule.py
+++ b/lib/ansiblelint/rules/NoTabsRule.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
+from typing import List, Optional
 
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import TargetFile
 from ansiblelint.rules import AnsibleLintRule
 
 
@@ -12,5 +15,8 @@ class NoTabsRule(AnsibleLintRule):
     tags = ['formatting']
     version_added = 'v4.0.0'
 
-    def match(self, file, line):
-        return '\t' in line
+    def match(self, file: TargetFile, line: str, line_no: Optional[int]) -> List[MatchError]:
+        result = []
+        if '\t' in line:
+            result.append(MatchError(rule=self.__class__))
+        return result

--- a/lib/ansiblelint/rules/PlaybookExtension.py
+++ b/lib/ansiblelint/rules/PlaybookExtension.py
@@ -2,9 +2,13 @@
 # Copyright (c) 2018, Ansible Project
 
 import os
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class PlaybookExtension(AnsibleLintRule):
@@ -13,16 +17,16 @@ class PlaybookExtension(AnsibleLintRule):
     description = 'Playbooks should have the ".yml" or ".yaml" extension'
     severity = 'MEDIUM'
     tags = ['formatting']
-    done = []  # type: List  # already noticed path list
+    done: List[str] = []
     version_added = 'v4.0.0'
 
-    def match(self, file, text):
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List["MatchError"]:
         if file['type'] != 'playbook':
-            return False
+            return []
 
         path = file['path']
         ext = os.path.splitext(path)
         if ext[1] not in ['.yml', '.yaml'] and path not in self.done:
             self.done.append(path)
-            return True
-        return False
+            return [MatchError(rule=self.__class__)]
+        return []

--- a/lib/ansiblelint/rules/TaskNoLocalAction.py
+++ b/lib/ansiblelint/rules/TaskNoLocalAction.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class TaskNoLocalAction(AnsibleLintRule):
@@ -12,7 +17,8 @@ class TaskNoLocalAction(AnsibleLintRule):
     tags = ['task']
     version_added = 'v4.0.0'
 
-    def match(self, file, text):
-        if 'local_action' in text:
-            return True
-        return False
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List[MatchError]:
+        result = []
+        if 'local_action' in line:
+            result.append(MatchError(rule=self.__class__))
+        return result

--- a/lib/ansiblelint/rules/TrailingWhitespaceRule.py
+++ b/lib/ansiblelint/rules/TrailingWhitespaceRule.py
@@ -17,8 +17,13 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class TrailingWhitespaceRule(AnsibleLintRule):
@@ -29,6 +34,9 @@ class TrailingWhitespaceRule(AnsibleLintRule):
     tags = ['formatting']
     version_added = 'historic'
 
-    def match(self, file, line):
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List[MatchError]:
+        result = []
         line = line.replace("\r", "")
-        return line.rstrip() != line
+        if line.rstrip() != line:
+            result.append(MatchError(filename=file['path'], details=line, rule=self.__class__))
+        return result

--- a/lib/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/lib/ansiblelint/rules/VariableHasSpacesRule.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
-
 import re
+from typing import TYPE_CHECKING, List, Optional
 
+from ansiblelint.errors import MatchError
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import TargetFile
 
 
 class VariableHasSpacesRule(AnsibleLintRule):
@@ -17,8 +21,13 @@ class VariableHasSpacesRule(AnsibleLintRule):
     variable_syntax = re.compile(r"{{.*}}")
     bracket_regex = re.compile(r"{{[^{' -]|[^ '}-]}}")
 
-    def match(self, file, line):
+    def match(self, file: "TargetFile", line: str, line_no: Optional[int]) -> List["MatchError"]:
         if not self.variable_syntax.search(line):
-            return
+            return []
         line_exclude_json = re.sub(r"[^{]{'\w+': ?[^{]{.*?}}", "", line)
-        return self.bracket_regex.search(line_exclude_json)
+        if self.bracket_regex.search(line_exclude_json):
+            return [MatchError(
+                filename=file['path'],
+                details=line,
+                rule=self.__class__)]
+        return []

--- a/test/TestLintRule.py
+++ b/test/TestLintRule.py
@@ -21,6 +21,8 @@
 # pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import unittest
 
+from ansiblelint.file_utils import TargetFile
+
 from .rules import EMatcherRule, UnsetVariableMatcherRule
 
 
@@ -32,7 +34,8 @@ class TestRule(unittest.TestCase):
         with open(filename) as f:
             text = f.read()
         ematcher = EMatcherRule.EMatcherRule()
-        matches = ematcher.matchlines(dict(path=filename, type='playbooks'), text)
+        file = TargetFile(path=filename, type='playbooks')
+        matches = ematcher.matchlines(file=file, text=text)
         self.assertEqual(len(matches), 3)
 
     def test_rule_postmatching(self):
@@ -41,5 +44,6 @@ class TestRule(unittest.TestCase):
         with open(filename) as f:
             text = f.read()
         rule = UnsetVariableMatcherRule.UnsetVariableMatcherRule()
-        matches = rule.matchlines(dict(path=filename, type='playbooks'), text)
+        file = TargetFile(path=filename, type='playbooks')
+        matches = rule.matchlines(file=file, text=text)
         self.assertEqual(len(matches), 2)

--- a/test/rules/EMatcherRule.py
+++ b/test/rules/EMatcherRule.py
@@ -1,3 +1,7 @@
+from typing import List, Optional
+
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import TargetFile
 from ansiblelint.rules import AnsibleLintRule
 
 
@@ -8,5 +12,7 @@ class EMatcherRule(AnsibleLintRule):
     shortdesc = 'The letter "e" is present'
     tags = ['fake', 'dummy', 'test1']
 
-    def match(self, filename, line):
-        return "e" in line
+    def match(self, file: TargetFile, line: str, line_no: Optional[int]) -> List[MatchError]:
+        if "e" in line:
+            return [self.create_matcherror()]
+        return []

--- a/test/rules/UnsetVariableMatcherRule.py
+++ b/test/rules/UnsetVariableMatcherRule.py
@@ -1,3 +1,7 @@
+from typing import List, Optional
+
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import TargetFile
 from ansiblelint.rules import AnsibleLintRule
 
 
@@ -8,5 +12,7 @@ class UnsetVariableMatcherRule(AnsibleLintRule):
                   'post templating that still contain {{'
     tags = ['fake', 'dummy', 'test2']
 
-    def match(self, filename, line):
-        return "{{" in line
+    def match(self, file: TargetFile, line: str, line_no: Optional[int]) -> List[MatchError]:
+        if "{{" in line:
+            return [self.create_matcherror()]
+        return []


### PR DESCRIPTION
Adds type checking to match and enforces it to return a specific format instead of the previous very-loose return
type.

`List[MatchError]` return type was picked because it presented few particular benefits:
- still evaluates as bool correctly, empty list means no match(es)
- easy to process (extend list, no conditionals)
- already used as return type by 22/30 internal rules
- would allow us to return multiple matches with different message  each

This change will allow us to improve its use and avoid weird bugs cause by unexpected objects. This change counts as **major** because is likely to affect users that have their own custom rules.
Updating the code to match the new required return type should be quite easy.

In order to avoid runtime exceptions when running with old custom rules that were not fixed, it will raise a specific new `E901: RuntimeErrorRule (901)` when it detects unexpected return value. This will allow user to either fix the broken rule or temporary ignore 901 errors until the custom rule is fixed.

Another change introduced by this change is introduction of TargetFile, class which allows us to group files with their types. This is very important feature because we need to easily distinguish between various file types (tasks, playbooks, galaxy, deps, ....) and to extend them without having to change method signatures in a huge number
of places.

Partial: #893