### PR TITLE
Add RuntimeErrorRule internal rule

### DIFF
--- a/lib/ansiblelint/_internal/rules.py
+++ b/lib/ansiblelint/_internal/rules.py
@@ -1,0 +1,49 @@
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from ansiblelint.errors import MatchError
+
+
+class BaseRule:
+    """Root class used by Rules."""
+
+    id: str = ""
+    tags: List[str] = []
+    shortdesc: str = ""
+    description: str = ""
+    version_added: str = ""
+    severity: str = ""
+    match = None
+    matchtask = None
+    matchplay = None
+
+    def matchlines(self, file, text) -> List["MatchError"]:
+        """Return matches found for a specific line."""
+        return []
+
+    def matchtasks(self, file: str, text: str) -> List["MatchError"]:
+        """Return matches for a tasks file."""
+        return []
+
+    def matchyaml(self, file: str, text: str) -> List["MatchError"]:
+        """Return matches found for a specific YAML text."""
+        return []
+
+    def verbose(self) -> str:
+        """Return a verbose representation of the rule."""
+        return self.id + ": " + self.shortdesc + "\n  " + self.description
+
+
+class RuntimeErrorRule(BaseRule):
+    """Used to identify errors."""
+
+    id = '999'
+    shortdesc = 'Unexpected internal error'
+    description = (
+        'This error can be caused by internal bugs but also by '
+        'custom rules. Instead of just stopping linter we generate there errors and '
+        'continue processing. This allows users to add this rule to warn list until '
+        'the root cause is fixed.')
+    severity = 'VERY_HIGH'
+    tags = ['core']
+    version_added = 'v5.0.0'

--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -1,6 +1,8 @@
 """Exceptions and error representations."""
 import functools
+from typing import Type
 
+from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
 from ansiblelint.file_utils import normpath
 
 
@@ -26,11 +28,12 @@ class MatchError(ValueError):
             linenumber=0,
             details: str = "",
             filename=None,
-            rule=None) -> None:
+            rule: Type[BaseRule] = RuntimeErrorRule
+            ) -> None:
         """Initialize a MatchError instance."""
         super().__init__(message)
 
-        if not (message or rule):
+        if rule is RuntimeErrorRule and not message:
             raise TypeError(
                 f'{self.__class__.__name__}() missing a '
                 "required argument: one of 'message' or 'rule'",

--- a/test/TestRulesCollection.py
+++ b/test/TestRulesCollection.py
@@ -43,7 +43,8 @@ def bracketsmatchtestfile():
 
 
 def test_load_collection_from_directory(test_rules_collection):
-    assert len(test_rules_collection) == 2
+    # two detected rules plus the internal 999 one
+    assert len(test_rules_collection) == 3
 
 
 def test_run_collection(test_rules_collection, ematchtestfile):


### PR DESCRIPTION
This change should add a RuntimeErrorRule which would be the implicit
rule used when creating MatchErrors without mentioning a specific rule.

Current implementation of MatchError has a default rule=None but we
want to drop it so we would no longer have a rule as Optional, as
this can easily cause runtime bug (like the example seen where
we fed it an object instead of a class inside create_matcherror()