### PR TITLE
Remove always_run in _sanitize_task

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -428,7 +428,7 @@ def _sanitize_task(task: dict) -> dict:
     result = task.copy()
     # task is an AnsibleMapping which inherits from OrderedDict, so we need
     # to use `del` to remove unwanted keys.
-    for k in ['skipped_rules', FILENAME_KEY, LINE_NUMBER_KEY]:
+    for k in ['skipped_rules', FILENAME_KEY, LINE_NUMBER_KEY, 'always_run']:
         if k in result:
             del result[k]
     return result
@@ -439,16 +439,6 @@ def _sanitize_task(task: dict) -> dict:
 def normalize_task_v2(task: dict) -> dict:  # noqa: C901
     """Ensure tasks have an action key and strings are converted to python objects."""
     result = dict()
-    if 'always_run' in task:
-        # FIXME(ssbarnea): Delayed import to avoid circular import
-        # See https://github.com/ansible/ansible-lint/issues/880
-        # noqa: # pylint:disable=cyclic-import,import-outside-toplevel
-        from ansiblelint.rules.AlwaysRunRule import AlwaysRunRule
-
-        raise MatchError(
-            rule=AlwaysRunRule,
-            filename=task[FILENAME_KEY],
-            linenumber=task[LINE_NUMBER_KEY])
 
     sanitized_task = _sanitize_task(task)
     mod_arg_parser = ModuleArgsParser(sanitized_task)

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -3,6 +3,6 @@ from ansiblelint.runner import Runner
 
 
 def test_example(default_rules_collection):
-    """example.yml is expected to have 5 match errors inside."""
+    """example.yml is expected to have 15 match errors inside."""
     result = Runner(default_rules_collection, 'examples/example.yml', [], [], []).run()
-    assert len(result) == 5
+    assert len(result) == 15


### PR DESCRIPTION
Instead of raising an MatchError when normalizing tasks with always_run which hides other rules matching with matchtasks or matchyaml, remove always_run from the result dict in _sanitize_task. The result is only passed to ModuleArgsParser, where we don't need it. The rules are still run against the original task containing always_run.

As a result this still raises 101 but also shows other error messages.

Fixes #1086
Fixes #880 