### PR TITLE
Change deprecated tag to deprecations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -486,7 +486,7 @@ The following shows the available tags in an example set of rules, and the rules
     behaviour ['[503]']
     bug ['[304]']
     command-shell ['[305]', '[302]', '[304]', '[306]', '[301]', '[303]']
-    deprecated ['[105]', '[104]', '[103]', '[101]', '[102]']
+    deprecations ['[105]', '[104]', '[103]', '[101]', '[102]']
     formatting ['[104]', '[203]', '[201]', '[204]', '[206]', '[205]', '[202]']
     idempotency ['[301]']
     idiom ['[601]', '[602]']
@@ -593,7 +593,7 @@ An example rule using ``match`` is:
         shortdesc = 'Deprecated variable declarations'
         description = 'Check for lines that have old style ${var} ' + \
                       'declarations'
-        tags = { 'deprecated' }
+        tags = { 'deprecations' }
 
         def match(self, file, line):
             return '${' in line

--- a/lib/ansiblelint/rules/AlwaysRunRule.py
+++ b/lib/ansiblelint/rules/AlwaysRunRule.py
@@ -26,7 +26,7 @@ class AlwaysRunRule(AnsibleLintRule):
     shortdesc = 'Deprecated always_run'
     description = 'Instead of ``always_run``, use ``check_mode``'
     severity = 'MEDIUM'
-    tags = ['deprecated', 'ANSIBLE0018']
+    tags = ['deprecations', 'ANSIBLE0018']
     version_added = 'historic'
 
     def matchtask(self, file, task):

--- a/lib/ansiblelint/rules/DeprecatedModuleRule.py
+++ b/lib/ansiblelint/rules/DeprecatedModuleRule.py
@@ -13,7 +13,7 @@ class DeprecatedModuleRule(AnsibleLintRule):
         'https://docs.ansible.com/ansible/latest/modules/list_of_all_modules.html'
     )
     severity = 'HIGH'
-    tags = ['deprecated']
+    tags = ['deprecations']
     version_added = 'v4.0.0'
 
     _modules = [

--- a/lib/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/lib/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -6,7 +6,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
     shortdesc = 'No Jinja2 in when'
     description = '``when`` is a raw Jinja2 expression, remove redundant {{ }} from variable(s).'
     severity = 'HIGH'
-    tags = ['deprecated', 'ANSIBLE0019']
+    tags = ['deprecations', 'ANSIBLE0019']
     version_added = 'historic'
 
     def _is_valid(self, when):

--- a/lib/ansiblelint/rules/RoleNames.py
+++ b/lib/ansiblelint/rules/RoleNames.py
@@ -46,7 +46,7 @@ class RoleNames(AnsibleLintRule):
     )
     severity = 'HIGH'
     done: List[str] = []  # already noticed roles list
-    tags = ['deprecated']
+    tags = ['deprecations']
     version_added = 'v4.3.0'
 
     ROLE_NAME_REGEXP = re.compile(ROLE_NAME_REGEX)

--- a/lib/ansiblelint/rules/SudoRule.py
+++ b/lib/ansiblelint/rules/SudoRule.py
@@ -6,7 +6,7 @@ class SudoRule(AnsibleLintRule):
     shortdesc = 'Deprecated sudo'
     description = 'Instead of ``sudo``/``sudo_user``, use ``become``/``become_user``.'
     severity = 'VERY_HIGH'
-    tags = ['deprecated', 'ANSIBLE0008']
+    tags = ['deprecations', 'ANSIBLE0008']
     version_added = 'historic'
 
     def _check_value(self, play_frag):

--- a/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/lib/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -33,7 +33,7 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
         'syntax ``{{ your_variable }}``'
     )
     severity = 'VERY_HIGH'
-    tags = ['deprecated', 'formatting', 'ANSIBLE0015']
+    tags = ['deprecations', 'formatting', 'ANSIBLE0015']
     version_added = 'historic'
 
     _jinja = re.compile(r"{{.*}}", re.DOTALL)


### PR DESCRIPTION
To avoid possible confusion that rules with the deprecated tag are
themselves deprecated, we rename the tag to deprecations.

Fixes #1106 