### PR TITLE
E701: Match only on meta/main.yml

### DIFF
--- a/lib/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/lib/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -57,6 +57,11 @@ class MetaMainHasInfoRule(AnsibleLintRule):
         if file['type'] != 'meta':
             return False
 
+        # since Ansible 2.10 we can add a meta/requirements.yml but
+        # we only want to match on meta/main.yml
+        if not file['path'].endswith('/main.yml'):
+            return False
+
         meta = {'meta/main.yml': data}
         galaxy_info = data.get('galaxy_info', False)
         if galaxy_info:


### PR DESCRIPTION
Since Ansible 2.10 we can have other files in meta/ but only `meta/main.yml` needs to contain galaxy_info.

Fixes #1096