### PR TITLE
warn_list: fix default handling and argument parsing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,6 +441,11 @@ The following values are supported, and function identically to their CLI counte
       - run_this_tag
     use_default_rules: true
     verbosity: 1
+    warn_list:
+      - skip_this_tag
+      - and_this_one_too
+      - skip_this_id
+      - '401'
 
 
 Pre-commit Setup

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -26,6 +26,7 @@ The following shows the available tags in an example set of rules, and the rules
     bug ['[304]']
     command-shell ['[305]', '[302]', '[304]', '[306]', '[301]', '[303]']
     deprecations ['[105]', '[104]', '[103]', '[101]', '[102]']
+    experimental ['[208]']
     formatting ['[104]', '[203]', '[201]', '[204]', '[206]', '[205]', '[202]']
     idempotency ['[301]']
     idiom ['[601]', '[602]']
@@ -58,6 +59,17 @@ It's also possible to skip specific rules by passing the rule ID. For example, t
 .. code-block:: bash
 
     $ ansible-lint -x 502 playbook.yml
+
+Ignoring Rules
+``````````````
+
+To only warn about rules, use the ``-w WARN_LIST`` option. In this example all rules are run, but if rules with the ``experimental`` tag match they only show an error message but don't change the exit code:
+
+.. code-block:: console
+
+    $ ansible-lint -w experimental playbook.yml
+
+The default value for ``WARN_LIST`` is ``['experimental']`` if you don't define your own either on the cli or in the config file. If you do define your own ``WARN_LIST`` you will need to add ``'experimental'`` to it if you don't want experimental rules to change your exit code.
 
 False Positives: Skipping Rules
 -------------------------------

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -153,15 +153,8 @@ def main() -> int:
     if isinstance(options.tags, str):
         options.tags = options.tags.split(',')
 
-    skip = set()
-    for s in options.skip_list:
-        skip.update(str(s).split(','))
-    options.skip_list = frozenset(skip)
-
-    warn = set()
-    for w in options.warn_list:
-        warn.update(str(w).split(','))
-    options.warn_list = frozenset(warn)
+    options.skip_list = _sanitize_list_options(options.skip_list)
+    options.warn_list = _sanitize_list_options(options.warn_list)
 
     matches = _get_matches(rules, options)
 
@@ -266,6 +259,13 @@ def _previous_revision():
     with cwd(worktree_dir):
         os.system(f"git checkout {revision}")
         yield
+
+
+def _sanitize_list_options(tag_list: list):
+    tags = set()
+    for t in tag_list:
+        tags.update(str(t).split(','))
+    return frozenset(tags)
 
 
 if __name__ == "__main__":

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -158,6 +158,11 @@ def main() -> int:
         skip.update(str(s).split(','))
     options.skip_list = frozenset(skip)
 
+    warn = set()
+    for w in options.warn_list:
+        warn.update(str(w).split(','))
+    options.warn_list = frozenset(warn)
+
     matches = _get_matches(rules, options)
 
     # Assure we do not print duplicates and the order is consistent

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -188,14 +188,24 @@ def merge_config(file_config, cli_config) -> NamedTuple:
     }
 
     if not file_config:
+        # use defaults if we don't have a config file and the commandline
+        # parameter is not set
+        for entry, default in lists_map.items():
+            if not getattr(cli_config, entry):
+                setattr(cli_config, entry, default)
         return cli_config
 
     for entry in bools:
         x = getattr(cli_config, entry) or file_config.get(entry, False)
         setattr(cli_config, entry, x)
 
+    # if either commandline parameter or config file option is set merge
+    # with the other, if neither is set use the default
     for entry, default in lists_map.items():
-        getattr(cli_config, entry).extend(file_config.get(entry, default))
+        if getattr(cli_config, entry) or entry in file_config.keys():
+            getattr(cli_config, entry).extend(file_config.get(entry, []))
+        else:
+            setattr(cli_config, entry, default)
 
     if 'verbosity' in file_config:
         cli_config.verbosity = (cli_config.verbosity +


### PR DESCRIPTION
`warn_list` as a comma delimited string wrongly throws exit code 2 when all rules are on the `warn_list`. When we split it like we do with `skip_list` everything works correctly.

Fix default handling:

If there is no config file and -w is NOT specified on the commandline
use the default value ['experimental'] for warn_list.

If there is a config file and -w is NOT specified on the commandline
use the value from the config file and discard the default.

If there is no config file and -w is specified on the commandline use
the value from the commandline and discard the default.

If there is a config file and -w is specified on the commandline merge
both values and discard the default.

Additionally document warn_list in README.rst.

Fixes #1107
Fixes #1081
Fixes #1102