### PR TITLE
Allow skipping action validation

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -19,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """Command line implementation."""
-
 import errno
 import logging
 import os
@@ -32,7 +31,8 @@ from typing import TYPE_CHECKING, Any, List, Set, Type, Union
 from rich.markdown import Markdown
 from rich.syntax import Syntax
 
-from ansiblelint import cli, formatters
+from ansiblelint import formatters
+from ansiblelint.cli import configure
 from ansiblelint.color import console, console_stderr
 from ansiblelint.file_utils import cwd
 from ansiblelint.generate_docs import rules_as_rich, rules_as_rst
@@ -122,11 +122,17 @@ warn_list:  # or 'skip_list' to silence them completely
         return 0
 
 
-def main() -> int:
+def main(args=None) -> int:
     """Linter CLI entry point."""
+    # We want to persist loaded config inside the module
+
+    if args is None:
+        args = sys.argv[1:]
+
     cwd = pathlib.Path.cwd()
 
-    options = cli.get_config(sys.argv[1:])
+    # this will also set options
+    options = configure(args)
 
     initialize_logger(options.verbosity)
     _logger.debug("Options: %s", options)

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -16,6 +16,9 @@ from ansiblelint.version import __version__
 _logger = logging.getLogger(__name__)
 _PATH_VARS = ['exclude_paths', 'rulesdir', ]
 
+# Allow reusing loaded config (options) from other modules
+options = argparse.Namespace(tags=[])
+
 
 def abspath(path: str, base_dir: str) -> str:
     """Make relative path absolute relative to given directory.
@@ -216,5 +219,11 @@ def get_config(arguments: List[str]):
 def print_help(file=sys.stdout):
     get_cli_parser().print_help(file=file)
 
+
+def configure(arguments: List[str]):
+    """Initialize configuration and also return it."""
+    global options  # pylint: disable=global-statement
+    options = get_config(arguments)
+    return options
 
 # vim: et:sw=4:syntax=python:ts=4:

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -26,6 +26,7 @@ import os
 import os.path
 import subprocess
 import sys
+from argparse import Namespace
 from pathlib import Path
 
 import pytest
@@ -76,6 +77,20 @@ def test_normalize(reference_form, alternate_forms):
 
     for form in alternate_forms:
         assert normal_form == utils.normalize_task(form, 'tasks.yml')
+
+
+def test_normalize_with_skip_action_validation():
+    """Validates that skip-action-validation is passed to ansible."""
+    # without this tag ansible would fail with a "couldn't resolve module/action"
+    # error but with it it will ignore missing module. Users should be warned
+    # that passing any non empty dictionary to the module will still produce
+    # an error like: this task '...' has extra params, which is only allowed
+    # in the following modules: ...
+
+    fake_options = Namespace(tags=["skip-action-validation"])
+    data = {"missing_module_foo": {}}
+    utils.normalize_task(
+        data, 'tasks.yml', options=fake_options)
 
 
 def test_normalize_complex_command():


### PR DESCRIPTION
To make way for modules called from a collection, ask Ansible to hold
off on parsing the module names. We cannot validate and guarantee,
successfully, that such modules are valid or not as part of a static
linting tool

Fixes #538