### PR TITLE
Moved two path utils to file_utils

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,7 @@ categories:
     labels:
       - 'feature'  # 006b75
       - 'enhancement'  # ededed
+      - 'refactoring'
   - title: 'Bugfixes'
     labels:
       - 'bug'  # fbca04

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -10,7 +10,7 @@ from typing import List, NamedTuple
 import yaml
 
 from ansiblelint.constants import DEFAULT_RULESDIR, INVALID_CONFIG_RC
-from ansiblelint.utils import expand_path_vars
+from ansiblelint.file_utils import expand_path_vars
 from ansiblelint.version import __version__
 
 _logger = logging.getLogger(__name__)

--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -1,7 +1,7 @@
 """Utility functions related to file operations."""
 import os
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, Union
+from typing import TYPE_CHECKING, Any, Iterator, List, Union
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3979
@@ -30,3 +30,18 @@ def cwd(path: Union[str, BasePathLike]) -> Iterator[None]:
         yield
     finally:
         os.chdir(old_pwd)
+
+
+def expand_path_vars(path: str) -> str:
+    """Expand the environment or ~ variables in a path string."""
+    # It may be possible for function to be called with a Path object
+    path = str(path).strip()
+    path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
+    return path
+
+
+def expand_paths_vars(paths: List[str]) -> List[str]:
+    """Expand the environment or ~ variables in a list."""
+    paths = [expand_path_vars(p) for p in paths]
+    return paths

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -184,7 +184,7 @@ class RulesCollection(object):
         """Initialize a RulesCollection instance."""
         if rulesdirs is None:
             rulesdirs = []
-        self.rulesdirs = ansiblelint.utils.expand_paths_vars(rulesdirs)
+        self.rulesdirs = ansiblelint.file_utils.expand_paths_vars(rulesdirs)
         self.rules: List[BaseRule] = []
         # internal rules included in order to expose them for docs as they are
         # not directly loaded by our rule loader.

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -49,7 +49,7 @@ class Runner(object):
     def _update_exclude_paths(self, exclude_paths: List[str]) -> None:
         if exclude_paths:
             # These will be (potentially) relative paths
-            paths = ansiblelint.utils.expand_paths_vars(exclude_paths)
+            paths = ansiblelint.file_utils.expand_paths_vars(exclude_paths)
             # Since ansiblelint.utils.find_children returns absolute paths,
             # and the list of files we create in `Runner.run` can contain both
             # relative and absolute paths, we need to cover both bases.

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -807,21 +807,6 @@ def get_playbooks_and_roles(options=None) -> List[str]:  # noqa: C901
     return role_dirs + playbooks
 
 
-def expand_path_vars(path: str) -> str:
-    """Expand the environment or ~ variables in a path string."""
-    # It may be possible for function to be called with a Path object
-    path = str(path).strip()
-    path = os.path.expanduser(path)
-    path = os.path.expandvars(path)
-    return path
-
-
-def expand_paths_vars(paths: List[str]) -> List[str]:
-    """Expand the environment or ~ variables in a list."""
-    paths = [expand_path_vars(p) for p in paths]
-    return paths
-
-
 def get_rules_dirs(rulesdir: List[str], use_default: bool) -> List[str]:
     """Return a list of rules dirs."""
     default_ruledirs = [DEFAULT_RULESDIR]

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -32,7 +32,7 @@ import pytest
 
 from ansiblelint import cli, constants, utils
 from ansiblelint.__main__ import initialize_logger
-from ansiblelint.file_utils import normpath
+from ansiblelint.file_utils import expand_path_vars, expand_paths_vars, normpath
 
 
 @pytest.mark.parametrize(('string', 'expected_cmd', 'expected_args', 'expected_kwargs'), (
@@ -148,8 +148,8 @@ def test_expand_path_vars(monkeypatch):
     """Ensure that tilde and env vars are expanded in paths."""
     test_path = '/test/path'
     monkeypatch.setenv('TEST_PATH', test_path)
-    assert utils.expand_path_vars('~') == os.path.expanduser('~')
-    assert utils.expand_path_vars('$TEST_PATH') == test_path
+    assert expand_path_vars('~') == os.path.expanduser('~')
+    assert expand_path_vars('$TEST_PATH') == test_path
 
 
 @pytest.mark.parametrize(('test_path', 'expected'), (
@@ -161,7 +161,7 @@ def test_expand_path_vars(monkeypatch):
 def test_expand_paths_vars(test_path, expected, monkeypatch):
     """Ensure that tilde and env vars are expanded in paths lists."""
     monkeypatch.setenv('TEST_PATH', '/test/path')
-    assert utils.expand_paths_vars([test_path]) == [expected]
+    assert expand_paths_vars([test_path]) == [expected]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This refactoring is needed in order to allow circular imports on upcoming change.

Related: https://github.com/ansible-community/ansible-lint/pull/1134