### PR TITLE
Fix playbook autodetection

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -687,7 +687,7 @@ def is_playbook(filename: str) -> bool:
     else:
         if (
             isinstance(f, AnsibleSequence) and
-            hasattr(f, 'keys') and
+            hasattr(next(iter(f), {}), 'keys') and
             playbooks_keys.intersection(next(iter(f), {}).keys())
         ):
             return True

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -242,7 +242,6 @@ def test_logger_debug(caplog):
     assert expected_info in caplog.record_tuples
 
 
-@pytest.mark.xfail
 def test_cli_auto_detect(capfd):
     """Test that run without arguments it will detect and lint the entire repository."""
     cmd = sys.executable, "-m", "ansiblelint", "-v", "-p", "--nocolor"
@@ -267,7 +266,6 @@ def test_cli_auto_detect(capfd):
     assert "Unknown file type: test/test/always-run-success.yml" not in err
 
 
-@pytest.mark.xfail
 def test_is_playbook():
     """Verify that we can detect a playbook as a playbook."""
     assert utils.is_playbook("test/test/always-run-success.yml")


### PR DESCRIPTION
Check the iterator item for attribute 'keys' not the DataLoader object
so playbooks are correctly detected.

Fixes #808 
Fixes #1049 