### PR TITLE
Refactor linting to use a Lintable object

### DIFF
--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -1,7 +1,9 @@
 """Utility functions related to file operations."""
 import os
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, List, Union
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
+
+from ansiblelint.constants import FileType
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3979
@@ -45,3 +47,26 @@ def expand_paths_vars(paths: List[str]) -> List[str]:
     """Expand the environment or ~ variables in a list."""
     paths = [expand_path_vars(p) for p in paths]
     return paths
+
+
+class Lintable:
+    """Defines a file/folder that can be linted.
+
+    Providing file content when creating the object allow creation of in-memory
+    instances that do not need files to be present on disk.
+    """
+
+    def __init__(self, name: str, content: Optional[str] = None, kind: Optional[FileType] = None):
+        """Create a Lintable instance."""
+        self.name = name
+        self._content = content
+        # TODO(ssbarnea): implement kind detection when not provided
+        self.kind = kind
+
+    @property
+    def content(self):
+        """Retried file content, from internal cache or disk."""
+        if self._content is None:
+            with open(self.name, mode='r', encoding='utf-8') as f:
+                self._content = f.read()
+        return self._content

--- a/test/TestImportWithMalformed.py
+++ b/test/TestImportWithMalformed.py
@@ -1,19 +1,16 @@
-from collections import namedtuple
-
 import pytest
 
-PlayFile = namedtuple('PlayFile', ['name', 'content'])
+from ansiblelint.file_utils import Lintable
 
-
-IMPORT_TASKS_MAIN = PlayFile('import-tasks-main.yml', '''
+IMPORT_TASKS_MAIN = Lintable('import-tasks-main.yml', '''
 - oops this is invalid
 ''')
 
-IMPORT_SHELL_PIP = PlayFile('import-tasks-main.yml', '''
+IMPORT_SHELL_PIP = Lintable('import-tasks-main.yml', '''
 - shell: pip
 ''')
 
-PLAY_IMPORT_TASKS = PlayFile('playbook.yml', '''
+PLAY_IMPORT_TASKS = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - import_tasks: import-tasks-main.yml

--- a/test/TestIncludeMissFileWithRole.py
+++ b/test/TestIncludeMissFileWithRole.py
@@ -1,49 +1,46 @@
-from collections import namedtuple
-
 import pytest
 
-PlayFile = namedtuple('PlayFile', ['name', 'content'])
+from ansiblelint.file_utils import Lintable
 
-
-PLAY_IN_THE_PLACE = PlayFile('playbook.yml', u'''
+PLAY_IN_THE_PLACE = Lintable('playbook.yml', u'''
 - hosts: all
   roles:
     - include_in_the_place
 ''')
 
-PLAY_RELATIVE = PlayFile('playbook.yml', u'''
+PLAY_RELATIVE = Lintable('playbook.yml', u'''
 - hosts: all
   roles:
     - include_relative
 ''')
 
-PLAY_MISS_INCLUDE = PlayFile('playbook.yml', u'''
+PLAY_MISS_INCLUDE = Lintable('playbook.yml', u'''
 - hosts: all
   roles:
     - include_miss
 ''')
 
-PLAY_ROLE_INCLUDED_IN_THE_PLACE = PlayFile('roles/include_in_the_place/tasks/main.yml', u'''
+PLAY_ROLE_INCLUDED_IN_THE_PLACE = Lintable('roles/include_in_the_place/tasks/main.yml', u'''
 ---
 - include_tasks: included_file.yml
 ''')
 
-PLAY_ROLE_INCLUDED_RELATIVE = PlayFile('roles/include_relative/tasks/main.yml', u'''
+PLAY_ROLE_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/main.yml', u'''
 ---
 - include_tasks: tasks/included_file.yml
 ''')
 
-PLAY_ROLE_INCLUDED_MISS = PlayFile('roles/include_miss/tasks/main.yml', u'''
+PLAY_ROLE_INCLUDED_MISS = Lintable('roles/include_miss/tasks/main.yml', u'''
 ---
 - include_tasks: tasks/noexist_file.yml
 ''')
 
-PLAY_INCLUDED_IN_THE_PLACE = PlayFile('roles/include_in_the_place/tasks/included_file.yml', u'''
+PLAY_INCLUDED_IN_THE_PLACE = Lintable('roles/include_in_the_place/tasks/included_file.yml', u'''
 - debug:
     msg: 'was found & included'
 ''')
 
-PLAY_INCLUDED_RELATIVE = PlayFile('roles/include_relative/tasks/included_file.yml', u'''
+PLAY_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/included_file.yml', u'''
 - debug:
     msg: 'was found & included'
 ''')

--- a/test/TestIncludeMissingFileRule.py
+++ b/test/TestIncludeMissingFileRule.py
@@ -1,34 +1,31 @@
-from collections import namedtuple
-
 import pytest
 
-PlayFile = namedtuple('PlayFile', ['name', 'content'])
+from ansiblelint.file_utils import Lintable
 
-
-PLAY_INCLUDING_PLAIN = PlayFile('playbook.yml', u'''
+PLAY_INCLUDING_PLAIN = Lintable('playbook.yml', u'''
 - hosts: all
   tasks:
     - include: some_file.yml
 ''')
 
-PLAY_INCLUDING_JINJA2 = PlayFile('playbook.yml', u'''
+PLAY_INCLUDING_JINJA2 = Lintable('playbook.yml', u'''
 - hosts: all
   tasks:
     - include: "{{ some_path }}/some_file.yml"
 ''')
 
-PLAY_INCLUDING_NOQA = PlayFile('playbook.yml', u'''
+PLAY_INCLUDING_NOQA = Lintable('playbook.yml', u'''
 - hosts: all
   tasks:
     - include: some_file.yml # noqa 505
 ''')
 
-PLAY_INCLUDED = PlayFile('some_file.yml', u'''
+PLAY_INCLUDED = Lintable('some_file.yml', u'''
 - debug:
     msg: 'was found & included'
 ''')
 
-PLAY_HAVING_TASK = PlayFile('playbook.yml', u'''
+PLAY_HAVING_TASK = Lintable('playbook.yml', u'''
 - name: Play
   hosts: all
   pre_tasks:

--- a/test/TestNestedJinjaRule.py
+++ b/test/TestNestedJinjaRule.py
@@ -20,15 +20,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
-from collections import namedtuple
-
 import pytest
 
-PlayFile = namedtuple('PlayFile', ['name', 'content'])
+from ansiblelint.file_utils import Lintable
 
-
-FAIL_TASK_1LN = PlayFile('playbook.yml', '''
+FAIL_TASK_1LN = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: one-level nesting
@@ -36,7 +32,7 @@ FAIL_TASK_1LN = PlayFile('playbook.yml', '''
         var_one: "2*(1+2) is {{ 2 * {{ 1 + 2 }} }}"
 ''')
 
-FAIL_TASK_1LN_M = PlayFile('playbook.yml', '''
+FAIL_TASK_1LN_M = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: one-level multiline nesting
@@ -47,7 +43,7 @@ FAIL_TASK_1LN_M = PlayFile('playbook.yml', '''
           }}
 ''')
 
-FAIL_TASK_2LN = PlayFile('playbook.yml', '''
+FAIL_TASK_2LN = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: two-level nesting
@@ -55,7 +51,7 @@ FAIL_TASK_2LN = PlayFile('playbook.yml', '''
         var_two: "2*(1+(3-1)) is {{ 2 * {{ 1 + {{ 3 - 1 }} }} }}"
 ''')
 
-FAIL_TASK_2LN_M = PlayFile('playbook.yml', '''
+FAIL_TASK_2LN_M = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: two-level multiline nesting
@@ -67,7 +63,7 @@ FAIL_TASK_2LN_M = PlayFile('playbook.yml', '''
           }} }}
 ''')
 
-FAIL_TASK_W_5LN = PlayFile('playbook.yml', '''
+FAIL_TASK_W_5LN = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: five-level wild nesting
@@ -75,7 +71,7 @@ FAIL_TASK_W_5LN = PlayFile('playbook.yml', '''
         var_three_wld: "{{ {{ {{ {{ {{ 234 }} }} }} }} }}"
 ''')
 
-FAIL_TASK_W_5LN_M = PlayFile('playbook.yml', '''
+FAIL_TASK_W_5LN_M = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: five-level wild multiline nesting
@@ -92,7 +88,7 @@ FAIL_TASK_W_5LN_M = PlayFile('playbook.yml', '''
           }}
 ''')
 
-SUCCESS_TASK_P = PlayFile('playbook.yml', '''
+SUCCESS_TASK_P = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: non-nested example
@@ -100,7 +96,7 @@ SUCCESS_TASK_P = PlayFile('playbook.yml', '''
         var_one: "number for 'one' is {{ 2 * 1 }}"
 ''')
 
-SUCCESS_TASK_P_M = PlayFile('playbook.yml', '''
+SUCCESS_TASK_P_M = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: multiline non-nested example
@@ -110,7 +106,7 @@ SUCCESS_TASK_P_M = PlayFile('playbook.yml', '''
           2 * 1 }}
 ''')
 
-SUCCESS_TASK_2P = PlayFile('playbook.yml', '''
+SUCCESS_TASK_2P = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: nesting far from each other
@@ -118,7 +114,7 @@ SUCCESS_TASK_2P = PlayFile('playbook.yml', '''
         var_two: "number for 'two' is {{ 2 * 1 }} and number for 'three' is {{ 4 - 1 }}"
 ''')
 
-SUCCESS_TASK_2P_M = PlayFile('playbook.yml', '''
+SUCCESS_TASK_2P_M = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: multiline nesting far from each other
@@ -129,7 +125,7 @@ SUCCESS_TASK_2P_M = PlayFile('playbook.yml', '''
           4 - 1 }}
 ''')
 
-SUCCESS_TASK_C_2P = PlayFile('playbook.yml', '''
+SUCCESS_TASK_C_2P = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: nesting close to each other
@@ -137,7 +133,7 @@ SUCCESS_TASK_C_2P = PlayFile('playbook.yml', '''
         var_three: "number for 'ten' is {{ 2 - 1 }}{{ 3 - 3 }}"
 ''')
 
-SUCCESS_TASK_C_2P_M = PlayFile('playbook.yml', '''
+SUCCESS_TASK_C_2P_M = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: multiline nesting close to each other
@@ -148,7 +144,7 @@ SUCCESS_TASK_C_2P_M = PlayFile('playbook.yml', '''
           }}{{ 3 - 3 }}
 ''')
 
-SUCCESS_TASK_PRINT = PlayFile('playbook.yml', '''
+SUCCESS_TASK_PRINT = Lintable('playbook.yml', '''
 - hosts: all
   tasks:
     - name: print curly braces


### PR DESCRIPTION
As we have several places where we need to pass not only the filename of a linted file but also its content or file type, it makes sense to use a class that defines such an object.