### PR TITLE
Made formatting easier to read

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -29,7 +29,8 @@ class MatchError(ValueError):
             linenumber: int = 0,
             details: str = "",
             filename: Optional[str] = None,
-            rule: Type[BaseRule] = RuntimeErrorRule
+            rule: Type[BaseRule] = RuntimeErrorRule,
+            tag: Optional[str] = None  # optional fine-graded tag
             ) -> None:
         """Initialize a MatchError instance."""
         super().__init__(message)
@@ -49,6 +50,7 @@ class MatchError(ValueError):
             self.filename = os.getcwd()
         self.rule = rule
         self.ignored = False  # If set it will be displayed but not counted as failure
+        self.tag = tag
 
     def __repr__(self) -> str:
         """Return a MatchError instance representation."""

--- a/lib/ansiblelint/formatters/__init__.py
+++ b/lib/ansiblelint/formatters/__init__.py
@@ -56,10 +56,17 @@ class Formatter(BaseFormatter):
 
     def format(self, match: "MatchError") -> str:
         _id = getattr(match.rule, 'id', '000')
-        return (
-            f"[error_code]{_id}[/] [error_title]{self.escape(match.message)}[/]\n"
-            f"[filename]{self._format_path(match.filename or '')}[/]:{match.linenumber}\n"
-            f"[dim]{match.details}[/]\n")
+        result = (
+            f"[error_code]{_id}[/][dim]:[/] [error_title]{self.escape(match.message)}[/]")
+        if match.tag:
+            result += f" [dim][error_code]({match.tag})[/][/]"
+        result += (
+            "\n"
+            f"[filename]{self._format_path(match.filename or '')}[/]:{match.linenumber}")
+        if match.details:
+            result += f" [dim]{match.details}[/]"
+        result += "\n"
+        return result
 
 
 class QuietFormatter(BaseFormatter):
@@ -71,11 +78,15 @@ class QuietFormatter(BaseFormatter):
 
 
 class ParseableFormatter(BaseFormatter):
+    """Parseable uses PEP8 compatible format."""
 
     def format(self, match: "MatchError") -> str:
-        return (
+        result = (
             f"[filename]{self._format_path(match.filename or '')}[/]:{match.linenumber}: "
-            f"[[error_code]E{match.rule.id}[/]] [dim]{self.escape(match.message)}[/]")
+            f"[error_code]E{match.rule.id}[/] [dim]{self.escape(match.message)}[/]")
+        if match.tag:
+            result += f" [dim][error_code]({match.tag})[/][/]"
+        return result
 
 
 class AnnotationsFormatter(BaseFormatter):
@@ -103,7 +114,7 @@ class AnnotationsFormatter(BaseFormatter):
         violation_details = self.escape(match.message)
         return (
             f"::{level} file={file_path},line={line_num},severity={severity}"
-            f"::[E{rule_id}] {violation_details}"
+            f"::E{rule_id} {violation_details}"
         )
 
     @staticmethod

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -35,14 +35,18 @@ class AnsibleLintRule(BaseRule):
             message: str = None,
             linenumber: int = 0,
             details: str = "",
-            filename: str = None) -> MatchError:
-        return MatchError(
+            filename: str = None,
+            tag: str = "") -> MatchError:
+        match = MatchError(
             message=message,
             linenumber=linenumber,
             details=details,
             filename=filename,
             rule=self.__class__
             )
+        if tag:
+            match.tag = tag
+        return match
 
     def matchlines(self, file, text) -> List[MatchError]:
         matches: List[MatchError] = []

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -85,7 +85,7 @@ class TestCliRolePaths(unittest.TestCase):
         role_path = 'roles/invalid-name'
 
         result = run_ansible_lint(role_path, cwd=cwd)
-        assert '106 Role name invalid-name does not match' in result.stdout
+        assert '106: Role name invalid-name does not match' in result.stdout
 
     def test_run_role_name_with_prefix(self):
         cwd = self.local_test_dir
@@ -110,7 +110,7 @@ class TestCliRolePaths(unittest.TestCase):
         role_path = 'roles/invalid_due_to_meta'
 
         result = run_ansible_lint(role_path, cwd=cwd)
-        assert '106 Role name invalid-due-to-meta does not match' in result.stdout
+        assert '106: Role name invalid-due-to-meta does not match' in result.stdout
 
 
 @pytest.mark.parametrize(('result', 'env'), (
@@ -128,7 +128,7 @@ def test_run_playbook_github(result, env):
     result_gh = run_ansible_lint(role_path, cwd=cwd, env=env)
 
     expected = (
-        '::error file=examples/example.yml,line=47,severity=MEDIUM::[E101] '
+        '::error file=examples/example.yml,line=47,severity=MEDIUM::E101 '
         'Deprecated always_run'
     )
     assert (expected in result_gh.stdout) is result

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -259,7 +259,7 @@ def test_cli_auto_detect(capfd):
     assert "Unknown file type: test/fixtures/unknown-type.yml" in err
     # An expected rule match from our examples
     assert "examples/roles/bobbins/tasks/main.yml:2: " \
-        "[E401] Git checkouts must contain explicit version" in out
+        "E401 Git checkouts must contain explicit version" in out
     # assures that our .ansible-lint exclude was effective in excluding github files
     assert "Unknown file type: .github/" not in out
     # assures that we can parse playbooks as playbooks


### PR DESCRIPTION
- parsable format is now matching pep8 and pylint format, as we removed the extra brackets around rule id
- if a specific tag is mentioned on a match, we also print it after the rule title, just like pylint does with its named-tags.
- avoided accidental double newline on default formatter
- this change is very subtile and does not affect the parseability as it affects only the free-form field.

Prepares-For: https://github.com/ansible-community/ansible-lint/pull/955