### PR TITLE
Don't import collections from relative paths

### DIFF
--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -180,7 +180,7 @@ def _set_collections_basedir(basedir: str):
 def find_children(playbook: Tuple[str, str], playbook_dir: str) -> List:
     if not os.path.exists(playbook[0]):
         return []
-    _set_collections_basedir(playbook_dir or '.')
+    _set_collections_basedir(playbook_dir or os.path.abspath('.'))
     add_all_plugin_dirs(playbook_dir or '.')
     if playbook[1] == 'role':
         playbook_ds = {'roles': [{'role': playbook[0]}]}


### PR DESCRIPTION
This change seems to work for me locally, not sure what else is necessary (are there tests for this scenario?) to get this merged.

Line 184 might have similar issues, could be that I just didn't hit them (yet). I'm not too familiar with the code base here, so I used this minimal change. An alternative approach might be to do the `os.path.abspath()` in `_set_collections_basedir()` instead.

Fixes: #1122