### PR TITLE
Assure MatchError takes a rule instance

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -1,7 +1,7 @@
 """Exceptions and error representations."""
 import functools
 import os
-from typing import Any, Optional, Type
+from typing import Any, Optional
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
 from ansiblelint.file_utils import normpath
@@ -29,13 +29,13 @@ class MatchError(ValueError):
             linenumber: int = 0,
             details: str = "",
             filename: Optional[str] = None,
-            rule: Type[BaseRule] = RuntimeErrorRule,
+            rule: BaseRule = RuntimeErrorRule(),
             tag: Optional[str] = None  # optional fine-graded tag
             ) -> None:
         """Initialize a MatchError instance."""
         super().__init__(message)
 
-        if rule is RuntimeErrorRule and not message:
+        if rule.__class__ is RuntimeErrorRule and not message:
             raise TypeError(
                 f'{self.__class__.__name__}() missing a '
                 "required argument: one of 'message' or 'rule'",

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -1,4 +1,5 @@
 """All internal ansible-lint rules."""
+import copy
 import glob
 import importlib.util
 import logging
@@ -42,7 +43,7 @@ class AnsibleLintRule(BaseRule):
             linenumber=linenumber,
             details=details,
             filename=filename,
-            rule=self.__class__
+            rule=copy.copy(self)
             )
         if tag:
             match.tag = tag
@@ -250,7 +251,7 @@ class RulesCollection(object):
             return [MatchError(
                 message=str(error),
                 filename=playbookfile['path'],
-                rule=LoadingFailureRule)]
+                rule=LoadingFailureRule())]
 
         for rule in self.rules:
             if not tags or not set(rule.tags).union([rule.id]).isdisjoint(tags):

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -119,6 +119,6 @@ class Runner(object):
                         self.playbooks.add((child['path'], child['type']))
                         files.append(child)
                 except MatchError as e:
-                    e.rule = LoadingFailureRule
+                    e.rule = LoadingFailureRule()
                     yield e
                 visited.add(arg)

--- a/lib/ansiblelint/utils.py
+++ b/lib/ansiblelint/utils.py
@@ -273,7 +273,7 @@ def _taskshandlers_children(basedir, k, v, parent_type: FileType) -> List:
     if v is None:
         raise MatchError(
             message="A malformed block was encountered while loading a block.",
-            rule=RuntimeErrorRule)
+            rule=RuntimeErrorRule())
     for th in v:
 
         # ignore empty tasks, `-`
@@ -458,7 +458,7 @@ def normalize_task_v2(task: dict) -> dict:  # noqa: C901
         action, arguments, result['delegate_to'] = mod_arg_parser.parse()
     except AnsibleParserError as e:
         raise MatchError(
-            rule=AnsibleParserErrorRule,
+            rule=AnsibleParserErrorRule(),
             message=e.message,
             filename=task.get(FILENAME_KEY, "Unknown"),
             linenumber=task.get(LINE_NUMBER_KEY, 0),

--- a/test/TestMatchError.py
+++ b/test/TestMatchError.py
@@ -76,9 +76,9 @@ def test_matcherror_invalid():
         # filenames takes priority in sorting
         (MatchError("a", filename="b"), MatchError("a", filename="a")),
         # rule id 501 > rule id 101
-        (MatchError(rule=BecomeUserWithoutBecomeRule), MatchError(rule=AlwaysRunRule)),
+        (MatchError(rule=BecomeUserWithoutBecomeRule()), MatchError(rule=AlwaysRunRule())),
         # rule id "200" > rule id 101
-        (MatchError(rule=AnsibleLintRuleWithStringId), MatchError(rule=AlwaysRunRule)),
+        (MatchError(rule=AnsibleLintRuleWithStringId()), MatchError(rule=AlwaysRunRule())),
         # details are taken into account
         (MatchError("a", details="foo"), MatchError("a", details="bar")),
     ))


### PR DESCRIPTION
Replace use of class with an instance of a Rule for MatchErrors, as
this will allows us to process rules that produce various different
error messages (aka meta-rules).

Prepares-For: #955