### PR TITLE
Assure that skipped tags do not endup being reported

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -50,6 +50,8 @@ class MatchError(ValueError):
             self.filename = os.getcwd()
         self.rule = rule
         self.ignored = False  # If set it will be displayed but not counted as failure
+        # This can be used by rules that can report multiple errors type, so
+        # we can still filter by them.
         self.tag = tag
 
     def __repr__(self) -> str:

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -262,6 +262,10 @@ class RulesCollection(object):
                     matches.extend(rule.matchtasks(playbookfile, text))
                     matches.extend(rule.matchyaml(playbookfile, text))
 
+        # some rules can produce matches with tags that are inside our
+        # skip_list, so we need to cleanse the matches
+        matches = [m for m in matches if m.tag not in skip_list]
+
         return matches
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Fixes filtering out of tags by assuring that we remove the skipped
ones from the final list of matches.

Some rules may produce violations with various tags, different from
the rule class. This will allow us to better control the skips.