### PR TITLE
Make Runner use lintables

### DIFF
--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -35,7 +35,7 @@ from ansiblelint.file_utils import cwd
 from ansiblelint.generate_docs import rules_as_rich, rules_as_rst
 from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import LintResult, Runner
-from ansiblelint.utils import get_playbooks_and_roles, get_rules_dirs
+from ansiblelint.utils import get_lintables, get_rules_dirs
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -234,16 +234,12 @@ def _render_matches(
 
 def _get_matches(rules: RulesCollection, options: "Namespace") -> LintResult:
 
-    if not options.playbook:
-        # no args triggers auto-detection mode
-        playbooks = get_playbooks_and_roles(options=options)
-    else:
-        playbooks = sorted(set(options.playbook))
+    lintables = get_lintables(options=options, args=options.lintables)
 
     matches = list()
     checked_files: Set[str] = set()
-    for playbook in playbooks:
-        runner = Runner(rules, playbook, options.tags,
+    for lintable in lintables:
+        runner = Runner(rules, lintable, options.tags,
                         options.skip_list, options.exclude_paths,
                         options.verbosity, checked_files)
         matches.extend(runner.run())

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -162,7 +162,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument('--version', action='version',
                         version='%(prog)s {ver!s}'.format(ver=__version__),
                         )
-    parser.add_argument(dest='playbook', nargs='*',
+    parser.add_argument(dest='lintables', nargs='*',
                         help="One or more files or paths. When missing it will "
                         " enable auto-detection mode.")
 

--- a/lib/ansiblelint/constants.py
+++ b/lib/ansiblelint/constants.py
@@ -26,4 +26,6 @@ FileType = Literal[
     "meta",  # role meta
     "tasks",
     "handlers",
+    "role",  # that is a folder!
+    "yaml",  # generic yaml file, previously reported as unknown file type
     ]

--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -72,3 +72,17 @@ class Lintable:
             with open(self.name, mode='r', encoding='utf-8') as f:
                 self._content = f.read()
         return self._content
+
+    def __hash__(self) -> int:
+        """Return a hash value of the lintables."""
+        return hash(tuple(self.name,))
+
+    def __eq__(self, other: object) -> bool:
+        """Identify whether the other object represents the same rule match."""
+        if isinstance(other, Lintable):
+            return bool(self.name == other.name)
+        return False
+
+    def __repr__(self) -> str:
+        """Return user friendly representation of a lintable."""
+        return f"{self.name} ({self.kind})"

--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -2,13 +2,14 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, FrozenSet, Generator, List, Optional, Set
+from typing import TYPE_CHECKING, Any, FrozenSet, Generator, List, Optional, Set, Union
 
 import ansiblelint.file_utils
 import ansiblelint.skip_utils
 import ansiblelint.utils
 from ansiblelint._internal.rules import LoadingFailureRule
 from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import Lintable
 
 if TYPE_CHECKING:
     from ansiblelint.rules import RulesCollection
@@ -31,7 +32,7 @@ class Runner(object):
     def __init__(
             self,
             rules: "RulesCollection",
-            playbook: str,
+            lintable: Union[Lintable, str],
             tags: FrozenSet[Any] = frozenset(),
             skip_list: Optional[FrozenSet[Any]] = frozenset(),
             exclude_paths: List[str] = [],
@@ -40,6 +41,13 @@ class Runner(object):
         """Initialize a Runner instance."""
         self.rules = rules
         self.playbooks = set()
+
+        # TODO(ssbarnea): Continue refactoring to make use of lintables
+        if isinstance(lintable, Lintable):
+            playbook = str(lintable.path)
+        else:
+            playbook = lintable
+
         # assume role if directory
         if os.path.isdir(playbook):
             self.playbooks.add((os.path.join(playbook, ''), 'role'))

--- a/lib/ansiblelint/testing/fixtures.py
+++ b/lib/ansiblelint/testing/fixtures.py
@@ -27,7 +27,7 @@ def runner(play_file_path, default_rules_collection):
     """Fixture to return a Runner() instance."""
     return Runner(
         rules=default_rules_collection,
-        playbook=play_file_path)
+        lintable=play_file_path)
 
 
 @pytest.fixture

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -24,6 +24,7 @@ import pytest
 
 from ansiblelint import formatters
 from ansiblelint.cli import abspath
+from ansiblelint.file_utils import Lintable
 from ansiblelint.runner import Runner
 
 LOTS_OF_WARNINGS_PLAYBOOK = abspath('examples/lots_of_warnings.yml', os.getcwd())
@@ -42,7 +43,7 @@ LOTS_OF_WARNINGS_PLAYBOOK = abspath('examples/lots_of_warnings.yml', os.getcwd()
 def test_runner(default_rules_collection, playbook, exclude, length) -> None:
     runner = Runner(
         rules=default_rules_collection,
-        playbook=playbook,
+        lintable=playbook,
         exclude_paths=exclude)
 
     matches = runner.run()
@@ -63,7 +64,7 @@ def test_runner_unicode_format(default_rules_collection, formatter_cls) -> None:
     formatter = formatter_cls(os.getcwd(), display_relative_path=True)
     runner = Runner(
         rules=default_rules_collection,
-        playbook='test/unicode.yml')
+        lintable=Lintable('test/unicode.yml', "playbook"))
 
     matches = runner.run()
 
@@ -74,7 +75,7 @@ def test_runner_unicode_format(default_rules_collection, formatter_cls) -> None:
 def test_runner_with_directory(default_rules_collection, directory_name) -> None:
     runner = Runner(
         rules=default_rules_collection,
-        playbook=directory_name)
+        lintable=directory_name)
     assert list(runner.playbooks)[0][1] == 'role'
 
 
@@ -84,7 +85,7 @@ def test_files_not_scanned_twice(default_rules_collection) -> None:
     filename = os.path.abspath('test/common-include-1.yml')
     runner = Runner(
         rules=default_rules_collection,
-        playbook=filename,
+        lintable=filename,
         verbosity=0,
         checked_files=checked_files)
     run1 = runner.run()
@@ -92,7 +93,7 @@ def test_files_not_scanned_twice(default_rules_collection) -> None:
     filename = os.path.abspath('test/common-include-2.yml')
     runner = Runner(
         rules=default_rules_collection,
-        playbook=filename,
+        lintable=filename,
         verbosity=0,
         checked_files=checked_files)
     run2 = runner.run()

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -32,7 +32,7 @@ import pytest
 
 from ansiblelint import cli, constants, utils
 from ansiblelint.__main__ import initialize_logger
-from ansiblelint.file_utils import expand_path_vars, expand_paths_vars, normpath
+from ansiblelint.file_utils import Lintable, expand_path_vars, expand_paths_vars, normpath
 
 
 @pytest.mark.parametrize(('string', 'expected_cmd', 'expected_args', 'expected_kwargs'), (
@@ -279,8 +279,8 @@ def test_auto_detect_exclude(monkeypatch):
         return ['foo/playbook.yml', 'bar/playbook.yml']
 
     monkeypatch.setattr(utils, 'get_yaml_files', mockreturn)
-    result = utils.get_playbooks_and_roles(options)
-    assert result == ['bar/playbook.yml']
+    result = utils.get_lintables(options)
+    assert result == [Lintable('bar/playbook.yml', kind='playbook')]
 
 
 _DEFAULT_RULEDIRS = [constants.DEFAULT_RULESDIR]

--- a/test/TestWithSkipTagId.py
+++ b/test/TestWithSkipTagId.py
@@ -12,7 +12,8 @@ class TestWithSkipTagId(unittest.TestCase):
     file = 'test/with-skip-tag-id.yml'
 
     def test_negative_no_param(self) -> None:
-        bad_runner = Runner(rules=self.collection, playbook=self.file)
+        bad_runner = Runner(
+            rules=self.collection, lintable=self.file)
         errs = bad_runner.run()
         self.assertGreater(len(errs), 0)
 
@@ -20,7 +21,7 @@ class TestWithSkipTagId(unittest.TestCase):
         with_id = 'YAML'
         bad_runner = Runner(
             rules=self.collection,
-            playbook=self.file,
+            lintable=self.file,
             tags=frozenset([with_id]))
         errs = bad_runner.run()
         self.assertGreater(len(errs), 0)
@@ -29,7 +30,7 @@ class TestWithSkipTagId(unittest.TestCase):
         with_tag = 'formatting'
         bad_runner = Runner(
             rules=self.collection,
-            playbook=self.file,
+            lintable=self.file,
             tags=frozenset([with_tag]))
         errs = bad_runner.run()
         self.assertGreater(len(errs), 0)
@@ -38,7 +39,7 @@ class TestWithSkipTagId(unittest.TestCase):
         skip_id = 'YAML'
         good_runner = Runner(
             rules=self.collection,
-            playbook=self.file,
+            lintable=self.file,
             skip_list=frozenset([skip_id]))
         self.assertEqual([], good_runner.run())
 
@@ -46,6 +47,6 @@ class TestWithSkipTagId(unittest.TestCase):
         skip_tag = 'formatting'
         good_runner = Runner(
             rules=self.collection,
-            playbook=self.file,
+            lintable=self.file,
             skip_list=frozenset([skip_tag]))
         self.assertEqual([], good_runner.run())


### PR DESCRIPTION
Increases the use of Lintable objects in our code, which will make the linting more generic, making easier to lint new file types.