### PR TITLE
Add column to MatchError hash calculation

### DIFF
--- a/lib/ansiblelint/errors.py
+++ b/lib/ansiblelint/errors.py
@@ -82,6 +82,9 @@ class MatchError(ValueError):
             str(getattr(self.rule, 'id', 0)),
             self.message,
             self.details,
+            # -1 is used here to force errors with no column to sort before
+            # all other errors.
+            -1 if self.column is None else self.column,
         )
 
     def __lt__(self, other: object) -> bool:

--- a/test/TestMatchError.py
+++ b/test/TestMatchError.py
@@ -81,6 +81,9 @@ def test_matcherror_invalid():
         (MatchError(rule=AnsibleLintRuleWithStringId()), MatchError(rule=AlwaysRunRule())),
         # details are taken into account
         (MatchError("a", details="foo"), MatchError("a", details="bar")),
+        # columns are taken into account
+        (MatchError("a", column=3), MatchError("a", column=1)),
+        (MatchError("a", column=3), MatchError("a")),
     ))
 class TestMatchErrorCompare:
 


### PR DESCRIPTION
Changes in this commit fix the regression we introduced when we added a column attribute to the MatchError class. Without this fix, two different MatchError instances could compare equal, resulting in losing messages while collecting the in a set.