### PR TITLE
E304: environment variable with shell is allowed

### DIFF
--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -26,7 +26,7 @@ class EnvVarsInCommandRule(AnsibleLintRule):
     id = '304'
     shortdesc = "Environment variables don't work as part of command"
     description = (
-        'Environment variables should be passed to ``shell`` or ``command`` '
+        'Environment variables should be passed to ``command`` '
         'through environment argument'
     )
     severity = 'VERY_HIGH'

--- a/lib/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/lib/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -24,10 +24,10 @@ from ansiblelint.utils import FILENAME_KEY, LINE_NUMBER_KEY, get_first_cmd_arg
 
 class EnvVarsInCommandRule(AnsibleLintRule):
     id = '304'
-    shortdesc = "Environment variables don't work as part of command"
+    shortdesc = "Command module does not accept setting environment variables inline"
     description = (
-        'Environment variables should be passed to ``command`` '
-        'through environment argument'
+        'Use ``environment:`` to set environment variables '
+        'or use ``shell`` module which accepts both'
     )
     severity = 'VERY_HIGH'
     tags = ['command-shell', 'bug']


### PR DESCRIPTION
The default rule 304 description is  “Environment variables should be passed to ``shell`` or ``command`` through environment argument“.  but in the code only ``command``, so need to fix it.
Reference: Pull Request https://github.com/ansible-community/ansible-lint/pull/477