### PR TITLE
Remove tests that do not pass Ansible own syntax check

### DIFF
--- a/test/TestLocalContent.py
+++ b/test/TestLocalContent.py
@@ -10,32 +10,3 @@ def test_local_collection(default_rules_collection):
 
     assert len(runner.playbooks) == 1
     assert len(results) == 0
-
-
-def test_roles_local_content(default_rules_collection):
-    """Assures local content in roles is found."""
-    playbook_path = 'test/local-content/test-roles-success/test.yml'
-    runner = Runner(default_rules_collection, playbook_path, [], [], [])
-    results = runner.run()
-
-    assert len(runner.playbooks) == 4
-    assert len(results) == 0
-
-
-def test_roles_local_content_failure(default_rules_collection):
-    """Assures local content in roles is found, even if Ansible itself has trouble."""
-    playbook_path = 'test/local-content/test-roles-failed/test.yml'
-    runner = Runner(default_rules_collection, playbook_path, [], [], [])
-    results = runner.run()
-
-    assert len(runner.playbooks) == 4
-    assert len(results) == 0
-
-
-def test_roles_local_content_failure_complete(default_rules_collection):
-    """Role with local content that is not found."""
-    playbook_path = 'test/local-content/test-roles-failed-complete/test.yml'
-    runner = Runner(default_rules_collection, playbook_path, [], [], [])
-    x = runner.run()
-    assert len(x) == 1
-    assert "couldn't resolve module" in x[0].message

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -34,10 +34,7 @@ LOTS_OF_WARNINGS_PLAYBOOK = abspath('examples/lots_of_warnings.yml', os.getcwd()
     ('test/nomatchestest.yml', [], 0),
     ('test/unicode.yml', [], 1),
     (LOTS_OF_WARNINGS_PLAYBOOK, [LOTS_OF_WARNINGS_PLAYBOOK], 0),
-    ('test/block.yml', [], 1),
-    ('test/block-null.yml', [], 1),
     ('test/become.yml', [], 0),
-    ('test/emptytags.yml', [], 0),
     ('test/contains_secrets.yml', [], 0),
 ))
 def test_runner(default_rules_collection, playbook, exclude, length) -> None:

--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -68,11 +68,6 @@ PLAYBOOK = '''\
       command: creates=B chmod 644 A
       tags:
         - skip_ansible_lint
-
-    - name: test invalid action (skipped)
-      foo: bar
-      tags:
-        - skip_ansible_lint
 '''
 
 ROLE_META = '''\

--- a/test/block-null.yml
+++ b/test/block-null.yml
@@ -1,4 +1,0 @@
----
-- hosts: all
-  tasks:
-    - block:

--- a/test/emptytags.yml
+++ b/test/emptytags.yml
@@ -1,7 +1,0 @@
----
-- hosts: all
-
-  tasks:
-  - name: hello world
-    debug: msg="hello world"
-    tags:

--- a/test/local-content/test-roles-failed-complete/test.yml
+++ b/test/local-content/test-roles-failed-complete/test.yml
@@ -1,5 +1,0 @@
----
-- name: Include role which expects module that is local to other role which is not loaded
-  hosts: localhost
-  roles:
-    - role2

--- a/test/local-content/test-roles-success/test.yml
+++ b/test/local-content/test-roles-success/test.yml
@@ -1,7 +1,0 @@
----
-- name: Use roles with local modules and test plugins
-  hosts: localhost
-  roles:
-    - role1
-    - role3
-    - role2


### PR DESCRIPTION
Remove tests or parts of tests that are failing `ansible-playbook --syntax-check`. We will still be able to identify these errors by relying on Ansible itself once PR #950 gets merged.