### PR TITLE
Remove retries on IOErrors

### DIFF
--- a/lib/ansiblelint/file_utils.py
+++ b/lib/ansiblelint/file_utils.py
@@ -86,7 +86,7 @@ class Lintable:
     def content(self) -> str:
         """Retried file content, from internal cache or disk."""
         if self._content is None:
-            with open(self.name, mode='r', encoding='utf-8') as f:
+            with open(self.path, mode='r', encoding='utf-8') as f:
                 self._content = f.read()
         return self._content
 

--- a/lib/ansiblelint/rules/__init__.py
+++ b/lib/ansiblelint/rules/__init__.py
@@ -7,7 +7,6 @@ import os
 import re
 from collections import defaultdict
 from importlib.abc import Loader
-from time import sleep
 from typing import Iterator, List, Optional, Union
 
 import ansiblelint.utils
@@ -217,26 +216,17 @@ class RulesCollection(object):
 
     def run(self, file: Lintable, tags=set(), skip_list=frozenset()) -> List[MatchError]:
         matches: List[MatchError] = list()
-        error: Optional[IOError] = None
 
-        for i in range(3):
-            try:
-                if file.content is not None:  # loads the file content
-                    break
-            except IOError as e:
-                _logger.warning(
-                    "Couldn't open %s - %s [try:%s]",
-                    file.path,
-                    e.strerror,
-                    i)
-                error = e
-                sleep(1)
-                continue
-        else:
+        try:
+            if file.content is not None:  # loads the file content
+                pass
+        except IOError as e:
             return [MatchError(
-                message=str(error),
-                filename=str(file.path),
-                rule=LoadingFailureRule())]
+                message=str(e),
+                filename=file,
+                rule=LoadingFailureRule(),
+                tag=e.__class__.__name__.lower()
+                )]
 
         for rule in self.rules:
             if not tags or not set(rule.tags).union([rule.id]).isdisjoint(tags):

--- a/test/TestIncludeMissFileWithRole.py
+++ b/test/TestIncludeMissFileWithRole.py
@@ -2,45 +2,45 @@ import pytest
 
 from ansiblelint.file_utils import Lintable
 
-PLAY_IN_THE_PLACE = Lintable('playbook.yml', u'''
+PLAY_IN_THE_PLACE = Lintable('playbook.yml', '''\
 - hosts: all
   roles:
     - include_in_the_place
 ''')
 
-PLAY_RELATIVE = Lintable('playbook.yml', u'''
+PLAY_RELATIVE = Lintable('playbook.yml', '''\
 - hosts: all
   roles:
     - include_relative
 ''')
 
-PLAY_MISS_INCLUDE = Lintable('playbook.yml', u'''
+PLAY_MISS_INCLUDE = Lintable('playbook.yml', '''\
 - hosts: all
   roles:
     - include_miss
 ''')
 
-PLAY_ROLE_INCLUDED_IN_THE_PLACE = Lintable('roles/include_in_the_place/tasks/main.yml', u'''
+PLAY_ROLE_INCLUDED_IN_THE_PLACE = Lintable('roles/include_in_the_place/tasks/main.yml', '''\
 ---
 - include_tasks: included_file.yml
 ''')
 
-PLAY_ROLE_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/main.yml', u'''
+PLAY_ROLE_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/main.yml', '''\
 ---
 - include_tasks: tasks/included_file.yml
 ''')
 
-PLAY_ROLE_INCLUDED_MISS = Lintable('roles/include_miss/tasks/main.yml', u'''
+PLAY_ROLE_INCLUDED_MISS = Lintable('roles/include_miss/tasks/main.yml', '''\
 ---
 - include_tasks: tasks/noexist_file.yml
-''')
+''', kind="tasks")
 
-PLAY_INCLUDED_IN_THE_PLACE = Lintable('roles/include_in_the_place/tasks/included_file.yml', u'''
+PLAY_INCLUDED_IN_THE_PLACE = Lintable('roles/include_in_the_place/tasks/included_file.yml', '''\
 - debug:
     msg: 'was found & included'
-''')
+''', kind="tasks")
 
-PLAY_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/included_file.yml', u'''
+PLAY_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/included_file.yml', '''\
 - debug:
     msg: 'was found & included'
 ''')
@@ -57,15 +57,10 @@ PLAY_INCLUDED_RELATIVE = Lintable('roles/include_relative/tasks/included_file.ym
 )
 @pytest.mark.usefixtures('_play_files')
 def test_cases_warning_message(runner, caplog):
-    runner.run()
-    noexist_message_count = 0
+    result = runner.run()
 
-    for record in caplog.records:
-        print(record)
-        if "Couldn't open" in str(record):
-            noexist_message_count += 1
-
-    assert noexist_message_count == 3  # 3 retries
+    assert len(result) == 1
+    assert "No such file or directory" in result[0].message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reverts #1039 which added retries for IOErrors and also fixes related
bug where Lintable.content was using name instead of path, so not
working correctly in some cases.

From now the exception class name is also added as rule tag, making
easier to distinguish between them.