### PR TITLE
Avoid checking the same files more than once

### DIFF
--- a/lib/ansiblelint/runner.py
+++ b/lib/ansiblelint/runner.py
@@ -92,9 +92,9 @@ class Runner(object):
             # remove duplicates from files list
             files = [value for n, value in enumerate(files) if value not in files[:n]]
 
-            # remove files that have already been checked
-            files = [x for x in files if x.path not in self.checked_files]
             for file in files:
+                if str(file.path) in self.checked_files:
+                    continue
                 _logger.debug(
                     "Examining %s of type %s",
                     ansiblelint.file_utils.normpath(file.path),
@@ -107,7 +107,7 @@ class Runner(object):
         # update list of checked files
         self.checked_files.update([str(x.path) for x in files])
 
-        return sorted(list(set(matches)))
+        return sorted(set(matches))
 
     def _emit_matches(self, files: List[Lintable]) -> Generator[MatchError, None, None]:
         visited: Set = set()

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -86,6 +86,8 @@ def test_files_not_scanned_twice(default_rules_collection) -> None:
         verbosity=0,
         checked_files=checked_files)
     run1 = runner.run()
+    assert len(runner.checked_files) == 2
+    assert len(run1) == 1
 
     filename = os.path.abspath('examples/playbooks/common-include-2.yml')
     runner = Runner(
@@ -94,8 +96,7 @@ def test_files_not_scanned_twice(default_rules_collection) -> None:
         verbosity=0,
         checked_files=checked_files)
     run2 = runner.run()
-
-    assert len(run1) == 1
-    assert len(run2) == 1
-    # the error is shared from included file, so it should be counted once
-    assert len(set(run1 + run2)) == 1
+    assert len(runner.checked_files) == 3
+    # this second run should return 0 because the included filed was already
+    # processed and added to checked_files, which acts like a bypass list.
+    assert len(run2) == 0


### PR DESCRIPTION
Avoids bug where files were checked twice because we forgot that the checked_files list is dynamically updated.

Also removes redundant casting at the end.