### PR TITLE
Avoid using extras from git

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -31,21 +31,21 @@ related to containers and use the discussions_ forum instead.
 
     * ``core`` - will install latest version of ansible-base 2.10
     * ``community`` - will install latest version of ansible 2.10 with community collections
-    * ``devel`` - will install Ansible from git devel branch (unsupported)
 
 Using Pip
 ---------
 
 .. code-block:: bash
 
-    # Assuming you already installed ansible:
-    pip install ansible-lint
+    # Assuming you already installed ansible and you also want the optional
+    # yamllint support:
+    pip install "ansible-lint[yamllint]"
 
     # If you want to install and use latest ansible (w/o community collections)
-    pip install "ansible-lint[core]"
+    pip install "ansible-lint[core,yamllint]"
 
     # If you want to install and use latest ansible with community collections
-    pip install "ansible-lint[community]"
+    pip install "ansible-lint[community,yamllint]"
 
     # If you want to install an older version of Ansible 2.9
     pip install ansible-lint "ansible>=2.9,<2.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,8 +94,9 @@ community =
 core =
   ansible-base>=2.10  # GPLv3+
 # will install ansible from devel branch, may break at any moment.
-devel =
-  ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
+; Disabled due to https://github.com/pypa/twine/issues/726
+; devel =
+;   ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
 # yamllint must remain optional
 yamllint =
   yamllint >= 1.25.0  # GPLv3

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,10 @@ description =
 extras =
   yamllint
   core: core
-  devel: devel
+  ; devel: devel
 deps =
   ansible29: ansible>=2.9,<2.10
+  devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
   -r test-requirements.in
   -c test-requirements.txt
 commands =


### PR DESCRIPTION
Uploading packages that use extras pointing to git is not currently
possible for pypi, so we use a different approach to test devel
branch of Ansible.

Related: https://github.com/pypa/twine/issues/726