### PR TITLE
Improve packaging checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ build-backend = "setuptools.build_meta"
 # `pyproject.toml` because our CI/CD appends one line in
 # the end when publishing non-tagged versions to test.pypi.org
 [tool.setuptools_scm]
+local_scheme = "no-local-version"

--- a/tools/check-missing-ansible.py
+++ b/tools/check-missing-ansible.py
@@ -1,7 +1,14 @@
 """Validates linter behavior when ansible python package is missing."""
-from subprocess import run
+import os
+import subprocess
 
 if __name__ == "__main__":
     cmd = ["ansible-lint", "--version"]
-    result = run(cmd, check=False)
-    assert result.returncode == 4  # missing ansible
+    result = subprocess.run(
+        cmd,
+        universal_newlines=True,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ)
+    assert result.returncode == 4, result  # missing ansible

--- a/tox.ini
+++ b/tox.ini
@@ -127,5 +127,5 @@ commands =
   twine check {toxinidir}/dist/*
   # Install the wheel
   sh -c "python3 -m pip install {toxinidir}/dist/*.whl"
-  # Check if ansible-lint fails due to missing ansible
-  python3 tools/check-missing-ansible.py
+  # Re-assure ansible is not installed
+  {envpython} tools/check-missing-ansible.py


### PR DESCRIPTION
- Avoids printing expected error when doing the test for missing Ansible.
- Assures that the locally builded version use versioning compatible with pypi.