### PR TITLE
Refactor logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
     - Sphinx>=3.1.2
     - enrich
     - yamllint
+    - enrich>=1.2.6
 - repo: https://github.com/pre-commit/mirrors-pylint
   rev: v2.6.0
   hooks:

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -30,6 +30,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, List, Set, Type, Union
 
 from enrich.console import should_do_markup
+from enrich.logging import RichHandler
 
 from ansiblelint import cli, formatters
 from ansiblelint.color import console, console_options, console_stderr, reconfigure, render_yaml
@@ -59,16 +60,18 @@ def initialize_logger(level: int = 0) -> None:
         2: logging.DEBUG
     }
 
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(levelname)-8s %(message)s')
-    handler.setFormatter(formatter)
-    logger = logging.getLogger(__package__)
+    handler = RichHandler(
+        console=console_stderr, show_time=False, show_path=False, markup=True
+    )   # type: ignore
+
+    logger = logging.getLogger()  # root logger
     logger.addHandler(handler)
+    logger.propagate = False
     # Unknown logging level is treated as DEBUG
     logging_level = VERBOSITY_MAP.get(level, logging.DEBUG)
     logger.setLevel(logging_level)
     # Use module-level _logger instance to validate it
-    _logger.debug("Logging initialized to level %s", logging_level)
+    logger.debug("Logging initialized to level %s", logging_level)
 
 
 def choose_formatter_factory(

--- a/src/ansiblelint/color.py
+++ b/src/ansiblelint/color.py
@@ -1,8 +1,10 @@
 """Console coloring and terminal support."""
+import copy
 from typing import Any, Dict
 
 import rich
 from rich.console import Console
+from rich.style import Style
 from rich.theme import Theme
 
 _theme = Theme({
@@ -12,7 +14,9 @@ _theme = Theme({
     "title": "yellow",
     "error_code": "bright_red",
     "error_title": "red",
-    "filename": "blue"
+    "filename": "blue",
+    # overrides rich defaults:
+    "repr.brace": Style(bold=False, dim=True),
 })
 console_options: Dict[str, Any] = {
     "emoji": False,
@@ -32,6 +36,8 @@ def reconfigure(new_options: Dict[str, Any]):
     global console_stderr  # pylint: disable=global-statement
 
     console_options = new_options
+    console_options_stderr = copy.copy(new_options)
+    console_options_stderr.update({'stderr': True})
     rich.reconfigure(**new_options)
     # see https://github.com/willmcgugan/rich/discussions/484#discussioncomment-200182
     console_options_stderr = console_options.copy()

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -111,4 +111,4 @@ class Lintable:
 
     def __repr__(self) -> str:
         """Return user friendly representation of a lintable."""
-        return f"{self.name} ({self.kind})"
+        return f"[repr.path]{self.name}[/repr.path] ({self.kind})"

--- a/src/ansiblelint/logger.py
+++ b/src/ansiblelint/logger.py
@@ -4,7 +4,7 @@ import time
 from contextlib import contextmanager
 from typing import Any
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__package__)
 
 
 @contextmanager
@@ -15,4 +15,4 @@ def timed_info(msg: Any, *args: Any):
         yield
     finally:
         elapsed = time.time() - start
-        _logger.info(msg + " (%.2fs)", *(*args, elapsed))
+        _logger.info(msg + " [repr.number]%.2fs[/repr.number]", *(*args, elapsed))

--- a/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
+++ b/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
@@ -37,7 +37,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
         if lintable.kind != 'playbook':
             return []
 
-        with timed_info("Executing syntax check on %s", lintable.path):
+        with timed_info("Executing syntax check on %s", lintable):
             cmd = ['ansible-playbook', '--syntax-check', str(lintable.path)]
             run = subprocess.run(
                 cmd,

--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -1,16 +1,14 @@
-import logging
 import os
 import sys
 from typing import TYPE_CHECKING, List
 
 from ansiblelint.file_utils import Lintable
+from ansiblelint.logger import _logger
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.skip_utils import get_rule_skips_from_line
 
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
-
-_logger = logging.getLogger(__name__)
 
 # yamllint is a soft-dependency (not installed by default)
 try:

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -95,10 +95,7 @@ class Runner(object):
             for file in files:
                 if str(file.path) in self.checked_files:
                     continue
-                _logger.debug(
-                    "Examining %s of type %s",
-                    ansiblelint.file_utils.normpath(file.path),
-                    file.kind)
+                _logger.debug("Examining %s", file)
 
                 matches.extend(
                     self.rules.run(file, tags=set(self.tags),

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -21,7 +21,6 @@
 
 import contextlib
 import inspect
-import logging
 import os
 import subprocess
 from argparse import Namespace
@@ -61,6 +60,7 @@ from ansiblelint._internal.rules import AnsibleParserErrorRule, LoadingFailureRu
 from ansiblelint.constants import CUSTOM_RULESDIR_ENVVAR, DEFAULT_RULESDIR, FileType
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable, normpath
+from ansiblelint.logger import _logger
 
 # ansible-lint doesn't need/want to know about encrypted secrets, so we pass a
 # string as the password to enable such yaml files to be opened and parsed
@@ -68,9 +68,6 @@ from ansiblelint.file_utils import Lintable, normpath
 DEFAULT_VAULT_PASSWORD = 'x'
 
 PLAYBOOK_DIR = os.environ.get('ANSIBLE_PLAYBOOK_DIR', None)
-
-
-_logger = logging.getLogger(__name__)
 
 
 def parse_yaml_from_file(filepath: str) -> dict:

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -187,7 +187,7 @@ def test_get_yaml_files_git_verbose(
     utils.get_yaml_files(options)
 
     expected_info = (
-        "ansiblelint.utils",
+        "ansiblelint",
         logging.INFO,
         'Discovering files to lint: git ls-files *.yaml *.yml')
 
@@ -208,6 +208,8 @@ def test_get_yaml_files_silent(is_in_git, monkeypatch, capsys):
     Also checks expected number of files are detected.
     """
     options = cli.get_config([])
+    options.vebosity = 0
+    options.quiet = True
     test_dir = Path(__file__).resolve().parent
     lint_path = test_dir / 'roles' / 'test-role'
     if not is_in_git:
@@ -234,7 +236,7 @@ def test_logger_debug(caplog):
     initialize_logger(options.verbosity)
 
     expected_info = (
-        "ansiblelint.__main__",
+        'root',
         logging.DEBUG,
         'Logging initialized to level 10',
     )


### PR DESCRIPTION
- Makes use of enrich log formatter in order to add coloring to log
  messages
- Use a single logger instance across the entire application

Example of logging output after this change:

![](https://sbarnea.com/ss/Screen-Shot-2021-01-08-15-49-59.42.png)
