### PR TITLE
Make pre-commit hook install all extras

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,3 +12,9 @@
     # https://github.com/ansible-community/ansible-lint/issues/611
     pass_filenames: false
     always_run: true
+    additional_dependencies:
+        # https://github.com/pre-commit/pre-commit/issues/1526
+        # if you want to use only the base ansible version for linting,
+        # replace 'community' extra with 'core' or just mention the exact
+        # version of Ansible you want to install as a dependency.
+        - .[community,yamllint]


### PR DESCRIPTION
This should make it much easier to migrate to 4.0 for pre-commit users as they would not be forced to update their hook configuration in order to run the linter.

Related: https://github.com/pre-commit/pre-commit/issues/1526