### PR TITLE
Auto-detect modules from collection layouts

### DIFF
--- a/examples/playbooks/custom_module.yml
+++ b/examples/playbooks/custom_module.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run custom module
+      fake_module: {}

--- a/lib/ansiblelint/_prerun.py
+++ b/lib/ansiblelint/_prerun.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from packaging import version
@@ -28,4 +29,12 @@ def check_ansible_presence() -> None:
         sys.exit(ANSIBLE_MISSING_RC)
 
 
+def prepare_environment() -> None:
+    """Make custom modules available if needed."""
+    if os.path.exists("plugins/modules") and 'ANSIBLE_LIBRARY' not in os.environ:
+        os.environ['ANSIBLE_LIBRARY'] = "plugins/modules"
+        print("Added ANSIBLE_LIBRARY=plugins/modules", file=sys.stderr)
+
+
 check_ansible_presence()
+prepare_environment()

--- a/plugins/modules/fake_module.py
+++ b/plugins/modules/fake_module.py
@@ -1,0 +1,16 @@
+"""Sample custom ansible module named fake_module.
+
+This is used to test ability to detect and use custom modules.
+"""
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """Return the module instance."""
+    return AnsibleModule(
+        argument_spec=dict(
+            data=dict(default=None),
+            path=dict(default=None, type=str),
+            file=dict(default=None, type=str),
+        )
+    )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,9 @@ attrs==20.3.0
 colorama==0.4.4
 commonmark==0.9.1
 coverage==5.3.1
+dataclasses==0.8
 execnet==1.7.1
+importlib-metadata==3.4.0
 iniconfig==1.1.1
 packaging==20.4
 pluggy==0.13.1
@@ -25,6 +27,7 @@ rich==9.5.1
 six==1.15.0
 toml==0.10.2
 typing-extensions==3.7.4.3
+zipp==3.4.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -14,3 +14,11 @@ def test_example_plain_string(default_rules_collection):
     assert len(result) == 1
     assert result[0].rule.id == "911"
     assert "A playbook must be a list of plays" in result[0].message
+
+
+def test_example_custom_module(default_rules_collection):
+    """custom_module.yml is expected to pass."""
+    result = Runner(
+        default_rules_collection,
+        'examples/playbooks/custom_module.yml', [], [], []).run()
+    assert len(result) == 0


### PR DESCRIPTION
Makes local modules available to ansible when the plugins/modules exists
on disk but only if the user did not already define ANSIBLE_LIBRARY.

This means that from now on users are not forced to use use the old
hack of defining ANSIBLE_LIBRARY=plugins/modules before running the
linter, something that made it harder to use with pre-commit, tox, CI.

If the variable is already defined or the folder does not exist,
nothing is done.

Fixes: #778