### PR TITLE
Refactor ANSI enablement logic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,7 @@ repos:
     args: []
     additional_dependencies:
     - Sphinx>=3.1.2
+    - enrich
     - yamllint
 - repo: https://github.com/pre-commit/mirrors-pylint
   rev: v2.6.0

--- a/lib/ansiblelint/__main__.py
+++ b/lib/ansiblelint/__main__.py
@@ -29,6 +29,8 @@ import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, List, Set, Type, Union
 
+from enrich.console import should_do_markup
+
 from ansiblelint import cli, formatters
 from ansiblelint.color import console, console_options, console_stderr, reconfigure, render_yaml
 from ansiblelint.file_utils import cwd
@@ -137,10 +139,9 @@ def main(argv: List[str] = None) -> int:
     options = cli.get_config(argv[1:])
 
     if options.colored is None:
-        options.colored = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
-    if options.colored is not None:
-        console_options["force_terminal"] = options.colored
-        reconfigure(console_options)
+        options.colored = should_do_markup()
+    console_options["force_terminal"] = options.colored
+    reconfigure(console_options)
 
     initialize_logger(options.verbosity)
     _logger.debug("Options: %s", options)

--- a/lib/ansiblelint/cli.py
+++ b/lib/ansiblelint/cli.py
@@ -143,13 +143,15 @@ def get_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument('-w', dest='warn_list', default=[], action='append',
                         help="only warn about these rules, unless overridden in "
                              "config file defaults to 'experimental'")
+    # Do not use store_true/store_false because they create opposite defaults.
     parser.add_argument('--nocolor', dest='colored',
-                        default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
-                        action='store_false',
-                        help="disable colored output")
+                        action='store_const',
+                        const=False,
+                        help="disable colored output, same as NO_COLOR=1")
     parser.add_argument('--force-color', dest='colored',
-                        action='store_true',
-                        help="Try force colored output (relying on ansible's code)")
+                        action='store_const',
+                        const=True,
+                        help="Force colored output, same as FORCE_COLOR=1")
     parser.add_argument('--exclude', dest='exclude_paths',
                         action=AbspathArgAction,
                         type=Path, default=[],

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ install_requires =
   # ansible-lint does not list ansible as direct dependency in order to
   # allow user to choose his target version. Be sure that you mention one
   # of the extras or install a specific version of ansible yourself.
+  enrich>=1.2.6
   packaging
   pyyaml
   rich>=9.5.1

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from ansiblelint.testing import run_ansible_lint
+from ansiblelint.text import strip_ansi_escape
 
 
 class TestCliRolePaths(unittest.TestCase):
@@ -85,7 +86,7 @@ class TestCliRolePaths(unittest.TestCase):
         role_path = 'roles/invalid-name'
 
         result = run_ansible_lint(role_path, cwd=cwd)
-        assert '106: Role name invalid-name does not match' in result.stdout
+        assert '106: Role name invalid-name does not match' in strip_ansi_escape(result.stdout)
 
     def test_run_role_name_with_prefix(self):
         cwd = self.local_test_dir
@@ -110,7 +111,8 @@ class TestCliRolePaths(unittest.TestCase):
         role_path = 'roles/invalid_due_to_meta'
 
         result = run_ansible_lint(role_path, cwd=cwd)
-        assert '106: Role name invalid-due-to-meta does not match' in result.stdout
+        assert ('106: Role name invalid-due-to-meta does not match' in
+                strip_ansi_escape(result.stdout))
 
     def test_run_single_role_path_with_roles_path_env(self):
         """Test for role name collision with ANSIBLE_ROLES_PATH.


### PR DESCRIPTION
Make use of move flexible coloring detection logic from enrich library and fixes bug where command line arguments did not work as expected.

This enables us to use all common environment variables used to control ANSI enablement or disablement. 

Note that enrich library is tiny and also has other features that we would like to make use of, like logging.