### PR TITLE
Auto-detect roles from collection layouts

### DIFF
--- a/lib/ansiblelint/_prerun.py
+++ b/lib/ansiblelint/_prerun.py
@@ -35,6 +35,10 @@ def prepare_environment() -> None:
         os.environ['ANSIBLE_LIBRARY'] = "plugins/modules"
         print("Added ANSIBLE_LIBRARY=plugins/modules", file=sys.stderr)
 
+    if os.path.exists("roles") and "ANSIBLE_ROLES_PATH" not in os.environ:
+        os.environ['ANSIBLE_ROLES_PATH'] = "roles"
+        print("Added ANSIBLE_ROLES_PATH=roles", file=sys.stderr)
+
 
 check_ansible_presence()
 prepare_environment()

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -94,7 +94,7 @@ class TestCliRolePaths(unittest.TestCase):
 
         result = run_ansible_lint(role_path, cwd=cwd)
         assert len(result.stdout) == 0
-        assert len(result.stderr) == 0
+        assert "Added ANSIBLE_ROLES_PATH=roles" in result.stderr
         assert result.returncode == 0
 
     def test_run_role_name_from_meta(self):
@@ -103,7 +103,7 @@ class TestCliRolePaths(unittest.TestCase):
 
         result = run_ansible_lint(role_path, cwd=cwd)
         assert len(result.stdout) == 0
-        assert len(result.stderr) == 0
+        assert "Added ANSIBLE_ROLES_PATH=roles" in result.stderr
         assert result.returncode == 0
 
     def test_run_invalid_role_name_from_meta(self):


### PR DESCRIPTION
Assures that if roles folder exists it is added to Ansible role
paths but only if user did not already define this variable.

This enables us to easily lint collections and avoid the less
convenient workarounds.

Follow-Up: #1226