### PR TITLE
E911: Included details about empty playbooks

### DIFF
--- a/examples/playbooks/empty_playbook.yml
+++ b/examples/playbooks/empty_playbook.yml
@@ -1,0 +1,3 @@
+# an empty playbook which makes ansible-playbook --syntax-check report
+# ERROR! Empty playbook, nothing to do
+# with exit code 4


### PR DESCRIPTION
Ansible fails syntax check on empty playbooks and this includes the error from Ansible when this happens instead of the generic syntax error match error.

![](https://sbarnea.com/ss/Screen-Shot-2021-01-13-17-21-43.png)