### PR TITLE
Auto install requirements into temp directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     files: >-
       ^setup\.py$
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v3.3.0
+  rev: v3.4.0
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
@@ -46,7 +46,7 @@ repos:
     types: [file, yaml]
     entry: yamllint --strict
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.6.4
+  rev: v5.7.0
   hooks:
   - id: isort
     args:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ colorama==0.4.4
 commonmark==0.9.1
 cryptography==3.3.1
 docutils==0.16
+enrich==1.2.6
 idna==2.10
 imagesize==1.2.0
 jinja2==2.11.2

--- a/lib/ansiblelint/_prerun.py
+++ b/lib/ansiblelint/_prerun.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 from packaging import version
@@ -38,6 +39,57 @@ def prepare_environment() -> None:
     if os.path.exists("roles") and "ANSIBLE_ROLES_PATH" not in os.environ:
         os.environ['ANSIBLE_ROLES_PATH'] = "roles"
         print("Added ANSIBLE_ROLES_PATH=roles", file=sys.stderr)
+
+    if os.path.exists("requirements.yml"):
+
+        cmd = [
+            "ansible-galaxy",
+            "install",
+            "--roles-path",
+            ".cache/roles",
+            "-vr",
+            "requirements.yml"
+            ]
+
+        print("Running %s" % " ".join(cmd))
+        run = subprocess.run(
+            cmd,
+            universal_newlines=True,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if run.returncode != 0:
+            sys.exit(run.returncode)
+
+        cmd = [
+            "ansible-galaxy",
+            "collection",
+            "install",
+            "-p",
+            ".cache/collections",
+            "-vr",
+            "requirements.yml"
+            ]
+
+        print("Running %s" % " ".join(cmd))
+        run = subprocess.run(
+            cmd,
+            universal_newlines=True,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if run.returncode != 0:
+            sys.exit(run.returncode)
+
+        if 'ANSIBLE_ROLES_PATH' in os.environ:
+            os.environ['ANSIBLE_ROLES_PATH'] = f".cache/roles:{os.environ['ANSIBLE_ROLES_PATH']}"
+        if 'ANSIBLE_COLLECTIONS_PATHS' in os.environ:
+            os.environ['ANSIBLE_COLLECTIONS_PATHS'] = \
+                f".cache/collections:{os.environ['ANSIBLE_COLLECTIONS_PATHS']}"
+        else:
+            os.environ['ANSIBLE_COLLECTIONS_PATHS'] = ".cache/collections"
 
 
 check_ansible_presence()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,9 +9,8 @@ attrs==20.3.0
 colorama==0.4.4
 commonmark==0.9.1
 coverage==5.3.1
-dataclasses==0.8
+enrich==1.2.6
 execnet==1.7.1
-importlib-metadata==3.4.0
 iniconfig==1.1.1
 packaging==20.4
 pluggy==0.13.1
@@ -27,7 +26,6 @@ rich==9.5.1
 six==1.15.0
 toml==0.10.2
 typing-extensions==3.7.4.3
-zipp==3.4.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
If `requirements.yml` is found, install **roles** and **collections** from it into a temporary folder in order to avoid runtime errors when ansible would not be able to find roles or modules.