### PR TITLE
Removed deprecated export

### DIFF
--- a/src/ansiblelint/__init__.py
+++ b/src/ansiblelint/__init__.py
@@ -20,10 +20,8 @@
 """Main ansible-lint package."""
 # prerun must run before any other imports
 import ansiblelint._prerun  # noqa
-from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.version import __version__
 
 __all__ = (
     "__version__",
-    "AnsibleLintRule"  # deprecated, import it directly from rules
 )


### PR DESCRIPTION
As AnsibleLintRule export from package root was deprecated for a long time, we remove it in 5.0.