### PR TITLE
Refactor module initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,5 @@ repos:
   rev: v2.6.0
   hooks:
   - id: pylint
+    # temporary workaround as pylint is not compatible with 3.9
+    language_version: "3.8"

--- a/src/ansiblelint/__init__.py
+++ b/src/ansiblelint/__init__.py
@@ -19,7 +19,6 @@
 # THE SOFTWARE.
 """Main ansible-lint package."""
 # prerun must run before any other imports
-import ansiblelint._prerun  # noqa
 from ansiblelint.version import __version__
 
 __all__ = (

--- a/src/ansiblelint/_prerun.py
+++ b/src/ansiblelint/_prerun.py
@@ -90,7 +90,3 @@ def prepare_environment() -> None:
                 f".cache/collections:{os.environ['ANSIBLE_COLLECTIONS_PATHS']}"
         else:
             os.environ['ANSIBLE_COLLECTIONS_PATHS'] = ".cache/collections"
-
-
-check_ansible_presence()
-prepare_environment()

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -11,7 +11,6 @@ import yaml
 
 from ansiblelint.constants import DEFAULT_RULESDIR, INVALID_CONFIG_RC
 from ansiblelint.file_utils import expand_path_vars
-from ansiblelint.version import __version__
 
 _logger = logging.getLogger(__name__)
 _PATH_VARS = ['exclude_paths', 'rulesdir', ]
@@ -161,8 +160,8 @@ def get_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument('-c', dest='config_file',
                         help='Specify configuration file to use.  '
                              'Defaults to ".ansible-lint"')
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s {ver!s}'.format(ver=__version__),
+    parser.add_argument('--version',
+                        action='store_true',
                         )
     parser.add_argument(dest='lintables', nargs='*',
                         help="One or more files or paths. When missing it will "

--- a/src/ansiblelint/color.py
+++ b/src/ansiblelint/color.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 import rich
 from rich.console import Console
+from rich.syntax import Syntax
 from rich.theme import Theme
 
 _theme = Theme({
@@ -42,4 +43,4 @@ def reconfigure(new_options: Dict[str, Any]):
 
 def render_yaml(text: str):
     """Colorize YAMl for nice display."""
-    return rich.syntax.Syntax(text, 'yaml', theme="ansi_dark")
+    return Syntax(text, 'yaml', theme="ansi_dark")

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -7,11 +7,7 @@ import sys
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from ansible import __version__ as ansible_version_str
-
-from ansiblelint.errors import MatchError
-from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import Runner
+from ansiblelint._prerun import prepare_environment
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3240
@@ -20,6 +16,16 @@ if TYPE_CHECKING:
 else:
     CompletedProcess = subprocess.CompletedProcess
 
+# Emulate command line execution initialization as without it Ansible module
+# would be loaded with incomplete module/role/collection list.
+prepare_environment()
+
+# pylint: disable=ungrouped-imports,wrong-import-position
+from ansible import __version__ as ansible_version_str  # noqa: E402
+
+from ansiblelint.errors import MatchError  # noqa: E402
+from ansiblelint.rules import RulesCollection  # noqa: E402
+from ansiblelint.runner import Runner  # noqa: E402
 
 ANSIBLE_MAJOR_VERSION = tuple(map(int, ansible_version_str.split('.')[:2]))
 

--- a/test/test_boot.py
+++ b/test/test_boot.py
@@ -1,0 +1,21 @@
+"""Test related to ansiblelint initialization."""
+import sys
+from subprocess import run
+
+import pytest
+
+
+@pytest.mark.parametrize('module', (
+    "ansiblelint",
+    "ansiblelint.__main__"))
+def test_import(module):
+    """Safeguard that Ansible does not become an implicit import."""
+    # We cannot test it directly because our test fixtures already do
+    # import Ansible, so we need to test this using a separated process.
+    result = run([
+        sys.executable,
+        "-c",
+        f"import {module}, sys; sys.exit(0 if 'ansible' not in sys.modules else 1)"],
+        check=False
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
Avoids importing ansible before we initialize the CLI and adds safeguard testing to avoid premature imports in the future.

Fixes: #1235