### PR TITLE
Run Ansible syntax check only on playbooks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,9 @@ doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error
 
+    # Ansible originated
+    ignore:The _yaml extension module is now located at yaml._yaml and its location is subject to change:DeprecationWarning:
+
     # TODO: delete the following ignores once Ansible that we support gets rid of `imp`
     # Ref: https://github.com/ansible-community/ansible-lint/pull/734
     ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning:ansible.plugins.loader

--- a/test/TestImportPlaybook.py
+++ b/test/TestImportPlaybook.py
@@ -9,7 +9,7 @@ def test_task_hook_import_playbook(default_rules_collection):
     results = runner.run()
 
     results_text = str(results)
-    assert len(runner.playbooks) == 2
+    assert len(runner.lintables) == 2
     assert len(results) == 2
     # Assures we detected the issues from imported playbook
     assert 'Commands should not change things' in results_text

--- a/test/TestLocalContent.py
+++ b/test/TestLocalContent.py
@@ -8,5 +8,5 @@ def test_local_collection(default_rules_collection):
     runner = Runner(default_rules_collection, playbook_path, [], [], [])
     results = runner.run()
 
-    assert len(runner.playbooks) == 1
+    assert len(runner.lintables) == 1
     assert len(results) == 0

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -73,7 +73,7 @@ def test_runner_with_directory(default_rules_collection, directory_name) -> None
     runner = Runner(
         rules=default_rules_collection,
         lintable=directory_name)
-    assert list(runner.playbooks)[0].kind == 'role'
+    assert list(runner.lintables)[0].kind == 'role'
 
 
 def test_files_not_scanned_twice(default_rules_collection) -> None:

--- a/test/TestTaskIncludes.py
+++ b/test/TestTaskIncludes.py
@@ -35,5 +35,5 @@ def test_included_tasks(default_rules_collection, filename, file_count, match_co
     lintable = Lintable(filename)
     runner = Runner(default_rules_collection, lintable, [], [], [])
     result = runner.run()
-    assert len(runner.playbooks) == file_count
+    assert len(runner.lintables) == file_count
     assert len(result) == match_count


### PR DESCRIPTION
- refactors var used to host files being linted to avoid confusions
- run ansible own syntax check only on playbooks as that is the
  only supported file type