### PR TITLE
Identify requirements.yml files

### DIFF
--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -26,6 +26,8 @@ FileType = Literal[
     "meta",  # role meta
     "tasks",
     "handlers",
+    # https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-roles-and-collections-from-the-same-requirements-yml-file
+    "requirements",
     "role",  # that is a folder!
     "yaml",  # generic yaml file, previously reported as unknown file type
     ]

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -63,7 +63,9 @@ class Lintable:
         self.path = Path(name)
         self._content = content
         if not kind:
-            if self.path.is_dir():
+            if str(self.path.name) == "requirements.yml":
+                kind = "requirements"
+            elif self.path.is_dir():
                 kind = "role"
             elif self.path.name in ['main.yml', 'main.yaml'] and self.path.parent.name == 'meta':
                 kind = "meta"

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -106,7 +106,7 @@ def _append_skipped_rules(
             # assume it is a playbook, check needs to be added higher in the
             # call stack, and can remove this except
             return pyyaml_data
-    elif file_type == 'yaml':
+    elif file_type in ['yaml', 'requirements']:
         return pyyaml_data
     else:
         raise RuntimeError('Unexpected file type: {}'.format(file_type))

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -785,6 +785,7 @@ def get_lintables(
 
         for p in map(Path, files):
 
+            # skip exclusions
             try:
                 for file_path in options.exclude_paths:
                     if str(p.resolve()).startswith(str(file_path)):
@@ -794,38 +795,44 @@ def get_lintables(
                 _logger.debug('Ignored %s due to: %s', p, e)
                 continue
 
-            if (next((i for i in p.parts if i.endswith('playbooks')), None) or
-                    'playbook' in p.parts[-1]):
-                if "roles" not in p.parts:
+            lintable = Lintable(normpath(p))
+            # TODO(ssbarnea): Remove deprecated detection logic and use only
+            # the one from inside Lintable constructor.
+            if lintable.kind in ('yaml', 'playbook'):
+                # Kept for compatibility until we migrate all into Lintable
+
+                if (next((i for i in p.parts if i.endswith('playbooks')), None) or
+                        'playbook' in p.parts[-1]):
+                    if "roles" not in p.parts:
+                        playbooks.append(normpath(p))
+                        continue
+
+                # ignore if any folder ends with _vars
+                if next((i for i in p.parts if i.endswith('_vars')), None):
+                    continue
+                if 'roles' in p.parts or '.' in role_dirs:
+                    if 'tasks' in p.parts and p.parts[-1] in ['main.yaml', 'main.yml']:
+                        role_dirs.append(str(p.parents[1]))
+                        continue
+                    if role_internals.intersection(p.parts):
+                        continue
+                    if 'tests' in p.parts:
+                        playbooks.append(normpath(p))
+                if 'molecule' in p.parts:
+                    if p.parts[-1] not in ['molecule.yml', 'config.yml']:
+                        playbooks.append(normpath(p))
+                    else:
+                        lintables.append(Lintable(normpath(p), kind="yaml"))
+                    continue
+                # hidden files are clearly not playbooks, likely config files.
+                if p.parts[-1].startswith('.'):
+                    continue
+
+                if is_playbook(str(p)):
                     playbooks.append(normpath(p))
                     continue
 
-            # ignore if any folder ends with _vars
-            if next((i for i in p.parts if i.endswith('_vars')), None):
-                continue
-            if 'roles' in p.parts or '.' in role_dirs:
-                if 'tasks' in p.parts and p.parts[-1] in ['main.yaml', 'main.yml']:
-                    role_dirs.append(str(p.parents[1]))
-                    continue
-                if role_internals.intersection(p.parts):
-                    continue
-                if 'tests' in p.parts:
-                    playbooks.append(normpath(p))
-            if 'molecule' in p.parts:
-                if p.parts[-1] not in ['molecule.yml', 'config.yml']:
-                    playbooks.append(normpath(p))
-                else:
-                    lintables.append(Lintable(normpath(p), kind="yaml"))
-                continue
-            # hidden files are clearly not playbooks, likely config files.
-            if p.parts[-1].startswith('.'):
-                continue
-
-            if is_playbook(str(p)):
-                playbooks.append(normpath(p))
-                continue
-
-            lintable = Lintable(normpath(p), kind="yaml")
+                lintable = Lintable(normpath(p), kind="yaml")
             _logger.info('Identified: %s', lintable)
             lintables.append(lintable)
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -284,6 +284,11 @@ def test_is_playbook():
         ("roles/foo/molecule/scen1/molecule.yml", "yaml"),  # molecule scenario config
         ("roles/foo/molecule/scen2/foobar.yml", "playbook"),  # custom playbook name
         ("roles/foo/molecule/scen3/converge.yml", "playbook"),  # common playbook name
+        # requirements (we do not support includes yet)
+        ("requirements.yml", "requirements"),  # collection requirements
+        ("roles/foo/meta/requirements.yml", "requirements"),  # inside role requirements
+        # Undeterminable files:
+        ("test/fixtures/unknown-type.yml", "yaml"),
     ),
 )
 def test_auto_detect(monkeypatch, path: str, kind: FileType) -> None:
@@ -293,9 +298,14 @@ def test_auto_detect(monkeypatch, path: str, kind: FileType) -> None:
     def mockreturn(options):
         return [path]
 
+    # assert Lintable is able to determine file type
+    # lintable_detected = Lintable(path)
+    lintable_expected = Lintable(path, kind=kind)
+    # assert lintable_detected == lintable_expected
+
     monkeypatch.setattr(utils, 'get_yaml_files', mockreturn)
     result = utils.get_lintables(options)
-    assert result == [Lintable(path, kind=kind)]
+    assert result == [lintable_expected]
 
 
 def test_auto_detect_exclude(monkeypatch):

--- a/test/test-role/meta/requirements.yml
+++ b/test/test-role/meta/requirements.yml
@@ -1,0 +1,3 @@
+---
+roles: []
+collections: []


### PR DESCRIPTION
This change only identifies `requirements.yml` files as specific file type. This allows us to distinguish them from
other file types that may share the same folders, like `meta/main.yml`. This enables us to write rules specific to then.