### PR TITLE
Store configured options inside a module

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -1,0 +1,20 @@
+"""Store configuration options as a singleton."""
+from argparse import Namespace
+
+options = Namespace(
+    colored=True,
+    cwd=".",
+    display_relative_path=True,
+    exclude_paths=[],
+    lintables=[],
+    listrules=False,
+    listtags=False,
+    parseable=False,
+    parseable_severity=False,
+    quiet=False,
+    rulesdirs=[],
+    skip_list=[],
+    tags=[],
+    verbosity=False,
+    warn_list=[],
+)


### PR DESCRIPTION
This refactoring will allow us to access configured options from
any submodule without having to create cyclic imports, mainly
because modules are singletons.