### PR TITLE
Refactored file kind detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
     - Sphinx>=3.1.2
     - enrich
     - yamllint
+    - wcmatch
 - repo: https://github.com/pre-commit/mirrors-pylint
   rev: v2.6.0
   hooks:
@@ -86,3 +87,4 @@ repos:
     - rich
     - ruamel.yaml
     - sphinx
+    - wcmatch

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,6 @@ ignore_missing_imports = True
 
 [mypy-yamllint.*]
 ignore_missing_imports = True
+
+[mypy-wcmatch.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ install_requires =
   ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
   # NOTE: per issue #509 0.15.34 included in debian backports
   typing-extensions; python_version < "3.8"
+  wcmatch>=7.0  # MIT
 
 [options.entry_points]
 console_scripts =

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -204,10 +204,12 @@ def merge_config(file_config, cli_config: Namespace) -> Namespace:
     # if either commandline parameter or config file option is set merge
     # with the other, if neither is set use the default
     for entry, default in lists_map.items():
-        if getattr(cli_config, entry) or entry in file_config.keys():
-            getattr(cli_config, entry).extend(file_config.get(entry, []))
+        if getattr(cli_config, entry, None) or entry in file_config.keys():
+            value = getattr(cli_config, entry, [])
+            value.extend(file_config.get(entry, []))
         else:
-            setattr(cli_config, entry, default)
+            value = default
+        setattr(cli_config, entry, value)
 
     if 'verbosity' in file_config:
         cli_config.verbosity = (cli_config.verbosity +

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -1,6 +1,24 @@
 """Store configuration options as a singleton."""
 from argparse import Namespace
 
+DEFAULT_KINDS = [
+  # Do not sort this list, order matters.
+  {"requirements": "requirements.yml"},  # v2 and v1
+  {"requirements": "**/meta/requirements.yml"},  # v1 only
+  {"playbook": "**/playbooks/*.{yml,yaml}"},
+  {"playbook": "**/*playbook*.{yml,yaml}"},
+  {"role": "**/roles/*/"},
+  {"tasks": "**/tasks/*.{yaml,yml}"},
+  {"handlers": "**/handlers/*.{yaml,yml}"},
+  {"vars": "**/{vars,defaults}/*.{yaml,yml}"},
+  {"meta": "**/meta/main.{yaml,yml}"},
+  {"yaml": ".config/molecule/config.{yaml,yml}"},  # molecule global config
+  {"yaml": "**/molecule/*/molecule.{yaml,yml}"},  # molecule config
+  {"playbook": "**/molecule/*/*.{yaml,yml}"},  # molecule playbooks
+  {"yaml": "**/*.{yaml,yml}"},
+  {"yaml": "**/.*.{yaml,yml}"},
+]
+
 options = Namespace(
     colored=True,
     cwd=".",
@@ -17,4 +35,5 @@ options = Namespace(
     tags=[],
     verbosity=False,
     warn_list=[],
+    kinds=DEFAULT_KINDS,
 )

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -4,6 +4,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
+import wcmatch.pathlib
+
+from ansiblelint.config import options
 from ansiblelint.constants import FileType
 
 if TYPE_CHECKING:
@@ -50,6 +53,26 @@ def expand_paths_vars(paths: List[str]) -> List[str]:
     return paths
 
 
+def kind_from_path(path: Path):
+    """Determine the file kind based on its name."""
+    # pathlib.Path.match patterns are very limited, they do not support *a*.yml
+    # glob.glob supports **/foo.yml but not multiple extensions
+    pathex = wcmatch.pathlib.PurePath(path)
+    for entry in options.kinds:
+        for k, v in entry.items():
+            if pathex.globmatch(
+                    v,
+                    flags=(
+                        wcmatch.pathlib.GLOBSTAR |
+                        wcmatch.pathlib.BRACE |
+                        wcmatch.pathlib.DOTGLOB
+                    )):
+                return k
+    if path.is_dir():
+        return "role"
+    raise RuntimeError("Unable to determine file type for %s" % pathex)
+
+
 class Lintable:
     """Defines a file/folder that can be linted.
 
@@ -57,21 +80,21 @@ class Lintable:
     instances that do not need files to be present on disk.
     """
 
-    def __init__(self, name: str, content: Optional[str] = None, kind: Optional[FileType] = None):
+    def __init__(
+            self,
+            name: Union[str, Path],
+            content: Optional[str] = None,
+            kind: Optional[FileType] = None):
         """Create a Lintable instance."""
-        self.name = name
-        self.path = Path(name)
+        if isinstance(name, str):
+            self.name = name
+            self.path = Path(name)
+        else:
+            self.name = str(name)
+            self.path = name
         self._content = content
-        if not kind:
-            if str(self.path.name) == "requirements.yml":
-                kind = "requirements"
-            elif self.path.is_dir():
-                kind = "role"
-            elif self.path.name in ['main.yml', 'main.yaml'] and self.path.parent.name == 'meta':
-                kind = "meta"
-            else:
-                kind = "playbook"
-        self.kind = kind
+
+        self.kind = kind or kind_from_path(self.path)
         # We store absolute directory in dir
         if self.kind == "role":
             self.dir = str(self.path.resolve())
@@ -103,7 +126,7 @@ class Lintable:
 
     def __hash__(self) -> int:
         """Return a hash value of the lintables."""
-        return hash(tuple(self.name,))
+        return hash((self.name, self.kind))
 
     def __eq__(self, other: object) -> bool:
         """Identify whether the other object represents the same rule match."""

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -257,8 +257,6 @@ def test_cli_auto_detect(capfd):
 
     # Confirmation that it runs in auto-detect mode
     assert "Discovering files to lint: git ls-files *.yaml *.yml" in err
-    # Expected failure to detect file type"
-    assert "Identified: test/fixtures/unknown-type.yml (yaml)" in err
     # An expected rule match from our examples
     assert "examples/roles/bobbins/tasks/main.yml:2: " \
         "E401 Git checkouts must contain explicit version" in out
@@ -299,13 +297,15 @@ def test_auto_detect(monkeypatch, path: str, kind: FileType) -> None:
         return [path]
 
     # assert Lintable is able to determine file type
-    # lintable_detected = Lintable(path)
+    lintable_detected = Lintable(path)
     lintable_expected = Lintable(path, kind=kind)
-    # assert lintable_detected == lintable_expected
+    assert lintable_detected == lintable_expected
 
     monkeypatch.setattr(utils, 'get_yaml_files', mockreturn)
     result = utils.get_lintables(options)
-    assert result == [lintable_expected]
+    # get_lintable could return additional files and we only care to see
+    # that the given file is among the returned list.
+    assert lintable_expected in result
 
 
 def test_auto_detect_exclude(monkeypatch):


### PR DESCRIPTION
- Use configurable pattern list in order to determinate file kinds
- Keep current behavior: a file passed as argument must be a playbook