### PR TITLE
Prevents 403 to complain if update_only is set

### DIFF
--- a/examples/playbooks/package-check-failure.yml
+++ b/examples/playbooks/package-check-failure.yml
@@ -12,3 +12,9 @@
     package:
       name: some-package
       state: latest
+
+  - name: install ansible with update_only to false
+    yum:
+      name: sudo
+      state: latest
+      update_only: no

--- a/examples/playbooks/package-check-failure.yml
+++ b/examples/playbooks/package-check-failure.yml
@@ -17,4 +17,4 @@
     yum:
       name: sudo
       state: latest
-      update_only: no
+      update_only: false

--- a/examples/playbooks/package-check-success.yml
+++ b/examples/playbooks/package-check-success.yml
@@ -13,3 +13,9 @@
     package:
       name: some-package
       state: present
+
+  - name: update ansible
+    yum:
+      name: sudo
+      state: latest
+      update_only: yes

--- a/examples/playbooks/package-check-success.yml
+++ b/examples/playbooks/package-check-success.yml
@@ -18,4 +18,4 @@
     yum:
       name: sudo
       state: latest
-      update_only: yes
+      update_only: false

--- a/examples/playbooks/package-check-success.yml
+++ b/examples/playbooks/package-check-success.yml
@@ -18,4 +18,4 @@
     yum:
       name: sudo
       state: latest
-      update_only: false
+      update_only: true

--- a/src/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/src/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -66,4 +66,5 @@ class PackageIsNotLatestRule(AnsibleLintRule):
     def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
         return (task['action']['__ansible_module__'] in self._package_managers and
                 not task['action'].get('version') and
+                not task['action'].get('update_only') and
                 task['action'].get('state') == 'latest')

--- a/test/TestPackageIsNotLatest.py
+++ b/test/TestPackageIsNotLatest.py
@@ -25,4 +25,4 @@ class TestPackageIsNotLatestRule(unittest.TestCase):
             failure,
             rules=self.collection)
         errs = bad_runner.run()
-        self.assertEqual(3, len(errs))
+        self.assertEqual(4, len(errs))


### PR DESCRIPTION
- Adds test cases for success and failure to be sure is working with `update_only` set to `false` or `true`
- Adds an extra condition to check for update_only 

Fixes: #1277