### PR TITLE
Allow mocking of ansible modules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,4 @@
 exclude_paths:
 - .github/
+mock_modules:
+  - zuul_return

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -46,6 +46,9 @@ counterparts:
       - and_this_one_too
       - skip_this_id
       - '401'
+    mock_modules:
+      # Mock modules in order to pass ansible-playbook --syntax-check
+      - some_module
 
 
 Pre-commit Setup

--- a/examples/playbooks/mocked_module.yml
+++ b/examples/playbooks/mocked_module.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  tasks:
+    - name: some task
+      zuul_return: {}

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -207,6 +207,7 @@ def merge_config(file_config, cli_config: Namespace) -> Namespace:
         'skip_list': [],
         'tags': [],
         'warn_list': ['experimental'],
+        'mock_modules': []
     }
 
     if not file_config:

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -36,4 +36,5 @@ options = Namespace(
     verbosity=False,
     warn_list=[],
     kinds=DEFAULT_KINDS,
+    mock_modules=[]
 )

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -19,6 +19,21 @@ ANSIBLE_MISSING_RC = 4
 # Minimal version of Ansible we support for runtime
 ANSIBLE_MIN_VERSION = "2.9"
 
+ANSIBLE_MOCKED_MODULE = """\
+# This is a mocked Ansible module
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    return AnsibleModule(
+        argument_spec=dict(
+            data=dict(default=None),
+            path=dict(default=None, type=str),
+            file=dict(default=None, type=str),
+        )
+    )
+"""
+
 FileType = Literal[
     "playbook",
     "pre_tasks",

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -268,6 +268,9 @@ def test_cli_auto_detect(capfd):
     assert "Identified: .github/" not in out
     # assures that we can parse playbooks as playbooks
     assert "Identified: test/test/always-run-success.yml" not in err
+    # assure that zuul_return missing module is not reported
+    assert "examples/playbooks/mocked_module.yml" not in out
+    assert "Executing syntax check on examples/playbooks/mocked_module.yml" in err
 
 
 def test_is_playbook():


### PR DESCRIPTION
Allow user to define a list of module which will be mocked so
ansible syntax check would pass without complaining about them.

Using mocking is discouraged because it does prevent us from
identifying incorrect arguments being passed to these modules and
should be used only when installing the required modules is not
possible or too inconvenient.