### PR TITLE
E205: Assure extension is checked only for playbooks

### DIFF
--- a/src/ansiblelint/rules/PlaybookExtension.py
+++ b/src/ansiblelint/rules/PlaybookExtension.py
@@ -19,7 +19,9 @@ class PlaybookExtension(AnsibleLintRule):
     version_added = 'v4.0.0'
 
     def matchyaml(self, file: Lintable) -> List[MatchError]:
-        result = []
+        result: List[MatchError] = []
+        if file.kind != 'playbook':
+            return result
         path = str(file.path)
         ext = os.path.splitext(path)
         if ext[1] not in ['.yml', '.yaml'] and path not in self.done:


### PR DESCRIPTION
As now we can lint many other file types of YAML type, we want to assure extension checks happen only for playbooks.