### PR TITLE
Assure we process all lintables

### DIFF
--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -71,8 +71,10 @@ class YamllintRule(AnsibleLintRule):
 
     def matchyaml(self, file: Lintable) -> List["MatchError"]:
         """Return matches found for a specific YAML text."""
-        matches = []
+        matches: List["MatchError"] = []
         filtered_matches = []
+        if file.kind == 'role':
+            return matches
 
         if YamllintRule.config:
             for p in run_yamllint(file.content, YamllintRule.config):

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -218,16 +218,17 @@ class RulesCollection:
     def run(self, file: Lintable, tags=set(), skip_list: List[str] = []) -> List[MatchError]:
         matches: List[MatchError] = list()
 
-        try:
-            if file.content is not None:  # loads the file content
-                pass
-        except IOError as e:
-            return [MatchError(
-                message=str(e),
-                filename=file,
-                rule=LoadingFailureRule(),
-                tag=e.__class__.__name__.lower()
-                )]
+        if not file.path.is_dir():
+            try:
+                if file.content is not None:  # loads the file content
+                    pass
+            except IOError as e:
+                return [MatchError(
+                    message=str(e),
+                    filename=file,
+                    rule=LoadingFailureRule(),
+                    tag=e.__class__.__name__.lower()
+                    )]
 
         for rule in self.rules:
             if not tags or not set(rule.tags).union([rule.id]).isdisjoint(tags):

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -110,12 +110,10 @@ class Runner:
         # -- phase 2 ---
         if not matches:  # do our processing only when ansible syntax check passed
 
-            matches.extend(self._emit_matches(files))
-
             # remove duplicates from files list
             files = [value for n, value in enumerate(files) if value not in files[:n]]
 
-            for file in files:
+            for file in self.lintables:
                 if str(file.path) in self.checked_files:
                     continue
                 _logger.debug(

--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -106,7 +106,7 @@ def _append_skipped_rules(
             # assume it is a playbook, check needs to be added higher in the
             # call stack, and can remove this except
             return pyyaml_data
-    elif file_type in ['yaml', 'requirements']:
+    elif file_type in ['yaml', 'requirements', 'vars']:
         return pyyaml_data
     else:
         raise RuntimeError('Unexpected file type: {}'.format(file_type))

--- a/test/TestComparisonToLiteralBool.py
+++ b/test/TestComparisonToLiteralBool.py
@@ -66,4 +66,4 @@ class TestComparisonToLiteralBoolRule(unittest.TestCase):
 
     def test_literal_false(self):
         results = self.runner.run_role_tasks_main(FAIL_LITERAL_FALSE)
-        self.assertEqual(1, len(results))
+        assert len(results) == 1, results


### PR DESCRIPTION
Fixes regression happening while multi-phase linting was implemented,
which only used files that passed phase1 for phase2, missing the
fact that phase1 happens only for playbooks.

Also removes double call of _emit_matches().

This bug made made the linter ignore a single task file received as argument. Previously this was not even possible to encounter because only playbooks or roles were accepted as args.