### PR TITLE
Avoid printing internals with task_to_str

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -562,7 +562,7 @@ def task_to_str(task: Dict[str, Any]) -> str:
         return str(action)
     args = " ".join([
         "{0}={1}".format(k, v) for (k, v) in action.items()
-        if k not in ["__ansible_module__", "__ansible_arguments__"]])
+        if k not in ["__ansible_module__", "__ansible_arguments__", "__line__", "__file__"]])
     for item in action.get("__ansible_arguments__", []):
         args += f" {item}"
     return u"{0} {1}".format(action["__ansible_module__"], args)


### PR DESCRIPTION
As we already expose file and line number differently, we should not
expose these internal fields when using task_to_str.

This makes output easier to read.