### PR TITLE
Fix typos, minor writing style improvements in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,24 +13,24 @@ easily lead to bugs or make code harder to maintain.
 
 Ansible lint is also supposed to help users upgrade their code to work with
 newer versions of Ansible. Due to this reason we recommand using it with
-newest versions of Ansible, even if the version used in production may be
+the newest version of Ansible, even if the version used in production may be
 older.
 
-As any other linter, it is oppionated. Still, its rules are result of
+As any other linter, it is opinionated. Still, its rules are the result of
 community contributions and they can always be disabled based individually or
 by category by each user.
 
 `Ansible Galaxy project <https://github.com/ansible/galaxy/>`_ makes use of
 this linter in order to compute quality scores for `Galaxy Hub <https://galaxy.ansible.com>`_
-contributed content. This it does not mean this tool is aimed only to those
+contributed content. This does not mean this tool is aimed only to those
 that want to share their code. Files like ``galaxy.yml``, or sections like
-``galaxy_info`` inside ``meta.yml`` help documenting and maintenance, even
-without any publishing.
+``galaxy_info`` inside ``meta.yml`` help with documentation and maintenance,
+even for unpublished roles or collections.
 
 The project was originally started by `@willthames <https://github.com/willthames/>`_,
-and has since been adopted by Ansible Community team. Its development is purely
-community driven while keeping a permanent communications with other Ansible
-teams.
+and has since been adopted by the Ansible Community team. Its development is
+purely community driven, while keeping permanent communications with other
+Ansible teams.
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
Just a few small improvements to the documentation that I noticed when browsing https://github.com/ansible-community/ansible-lint/pull/1255.