### PR TITLE
E203: Respect skip_ansible_lint

### DIFF
--- a/src/ansiblelint/rules/NoTabsRule.py
+++ b/src/ansiblelint/rules/NoTabsRule.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
+from typing import Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import nested_items
 
 
 class NoTabsRule(AnsibleLintRule):
@@ -12,5 +14,10 @@ class NoTabsRule(AnsibleLintRule):
     tags = ['formatting']
     version_added = 'v4.0.0'
 
-    def match(self, line: str) -> bool:
-        return '\t' in line
+    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+        for k, v in nested_items(task):
+            if isinstance(k, str) and '\t' in k:
+                return True
+            if isinstance(v, str) and '\t' in v:
+                return True
+        return False

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -29,7 +29,7 @@ from collections import OrderedDict
 from collections.abc import ItemsView
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import yaml
 from ansible import constants
@@ -804,3 +804,17 @@ def get_lintables(
 def convert_to_boolean(value: Any) -> bool:
     """Use Ansible to convert something to a boolean."""
     return bool(boolean(value))
+
+
+def nested_items(data: Union[Dict[Any, Any], List[Any]]) -> Generator[Tuple[Any, Any], None, None]:
+    """Iterate a nested data structure."""
+    if isinstance(data, dict):
+        for k, v in data.items():
+            yield k, v
+            for k, v in nested_items(v):
+                yield k, v
+    if isinstance(data, list):
+        for item in data:
+            yield "list-item", item
+            for k, v in nested_items(item):
+                yield k, v

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -357,3 +357,22 @@ def test_get_rules_dirs_with_custom_rules(user_ruledirs, use_default, expected, 
     """Test it returns expected dir lists when custom rules exist."""
     monkeypatch.setenv(constants.CUSTOM_RULESDIR_ENVVAR, str(_CUSTOM_RULESDIR))
     assert get_rules_dirs(user_ruledirs, use_default) == expected
+
+
+def test_nested_items():
+    """Verify correct function of nested_items()."""
+    data = {
+        "foo": "text",
+        "bar": {"some": "text2"},
+        "fruits": ["apple", "orange"]
+    }
+
+    items = [
+        ("foo", "text"),
+        ("bar", {"some": "text2"}),
+        ("some", "text2"),
+        ("fruits", ["apple", "orange"]),
+        ("list-item", "apple"),
+        ("list-item", "orange")
+    ]
+    assert list(utils.nested_items(data)) == items


### PR DESCRIPTION
Reimplement rule using task parsing instead of line processing as
that is known not work with multiline strings.

Fixes: #1292