### PR TITLE
E206: Make us of matchtask

### DIFF
--- a/examples/playbooks/206.yml
+++ b/examples/playbooks/206.yml
@@ -29,7 +29,7 @@
     - name: bad variable format
       debug:
         msg: "{{bad_format }}"
-    - name: not a jinja variable
+    - name: not a jinja variable  # noqa 206
       debug:
         msg: "data = ${lookup{$local_part}lsearch{/etc/aliases}}"
     - name: JSON inside jinja is valid

--- a/src/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/src/ansiblelint/rules/VariableHasSpacesRule.py
@@ -3,8 +3,10 @@
 
 import re
 import sys
+from typing import Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import nested_items
 
 
 class VariableHasSpacesRule(AnsibleLintRule):
@@ -18,11 +20,13 @@ class VariableHasSpacesRule(AnsibleLintRule):
     variable_syntax = re.compile(r"{{.*}}")
     bracket_regex = re.compile(r"{{[^{' -]|[^ '}-]}}")
 
-    def match(self, line: str) -> bool:
-        if not self.variable_syntax.search(line):
-            return False
-        line_exclude_json = re.sub(r"[^{]{'\w+': ?[^{]{.*?}}", "", line)
-        return bool(self.bracket_regex.search(line_exclude_json))
+    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+        for k, v in nested_items(task):
+            if isinstance(v, str):
+                line_exclude_json = re.sub(r"[^{]{'\w+': ?[^{]{.*?}}", "", v)
+                if bool(self.bracket_regex.search(line_exclude_json)):
+                    return True
+        return False
 
 
 if 'pytest' in sys.modules:


### PR DESCRIPTION
This also fixes issue which prevented use of noqa, a known limitation of old match().

Related: https://github.com/ansible-community/ansible-lint/issues/1292