### PR TITLE
E206: Avoid false positives with multilines

### DIFF
--- a/examples/playbooks/206.yml
+++ b/examples/playbooks/206.yml
@@ -35,3 +35,14 @@
     - name: JSON inside jinja is valid
       debug:
         msg: "{{ {'test': {'subtest': variable}} }}"
+    - name: Avoid false positive on multiline
+      vars:
+        cases:
+          case1: >-
+            http://example.com/{{
+              case1 }}
+          case2: >-
+            http://example.com/{{
+            case2 }}
+      debug:
+        var: cases


### PR DESCRIPTION
- Fix regression caused by recent refactoring or rule on multilines
- Adds tests for preventing future regression
- Makes the error message mention the failure variable so user
  is not confused (reported line is the first of task, not the
  exact location within)
