### PR TITLE
Drop E suffix  when printing rule id

### DIFF
--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -83,7 +83,7 @@ class ParseableFormatter(BaseFormatter):
     def format(self, match: "MatchError") -> str:
         result = (
             f"[filename]{self._format_path(match.filename or '')}[/]:{match.position}: "
-            f"[error_code]E{match.rule.id}[/] [dim]{self.escape(match.message)}[/]")
+            f"[error_code]{match.rule.id}[/] [dim]{self.escape(match.message)}[/]")
         if match.tag:
             result += f" [dim][error_code]({match.tag})[/][/]"
         return result
@@ -137,7 +137,7 @@ class ParseableSeverityFormatter(BaseFormatter):
 
         filename = self._format_path(match.filename or "")
         position = match.position
-        rule_id = u"E{0}".format(match.rule.id)
+        rule_id = u"{0}".format(match.rule.id)
         severity = match.rule.severity
         message = self.escape(str(match.message))
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -263,7 +263,7 @@ def test_cli_auto_detect(capfd):
     assert "Discovering files to lint: git ls-files *.yaml *.yml" in err
     # An expected rule match from our examples
     assert "examples/playbooks/empty_playbook.yml:0: " \
-        "E911 Empty playbook, nothing to do" in out
+        "911 Empty playbook, nothing to do" in out
     # assures that our .ansible-lint exclude was effective in excluding github files
     assert "Identified: .github/" not in out
     # assures that we can parse playbooks as playbooks


### PR DESCRIPTION
From now on we no longer print E before rule id on parseable and
normal printing because it both reduced readability of the text
and also because it was misleading, some errors may be only
warnings but we always displayed only E.

This will also make it easier for us to migrate to text rule ids,
which are more human friendly.