### PR TITLE
Add codeclimate formatter (json)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,3 +91,10 @@ are also handled:
    :cwd: ..
    :returncode: 2
    :nostderr:
+
+A codeclimate report in JSON format can be generated with ansible-lint.
+
+.. command-output:: ansible-lint -f codeclimate examples/playbooks/example.yml
+   :cwd: ..
+   :returncode: 2
+   :nostderr:

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -29,9 +29,11 @@ class App:
     def render_matches(self, matches: List) -> None:
         """Display given matches."""
         if isinstance(self.formatter, formatters.CodeclimateJSONFormatter):
-            # If formatter CodeclimateJSONFormatter is chosen, 
+            # If formatter CodeclimateJSONFormatter is chosen,
             # then print only the matches in JSON
-            console.print(self.formatter.format_result(matches), markup=False, highlight=False)
+            console.print(
+                self.formatter.format_result(matches), markup=False, highlight=False
+            )
             return None
 
         ignored_matches = [match for match in matches if match.ignored]

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -31,7 +31,7 @@ class App:
         if isinstance(self.formatter, formatters.CodeclimateJSONFormatter):
             # If formatter CodeclimateJSONFormatter is chosen, 
             # then print only the matches in JSON
-            console.print(self.formatter.format(matches), markup=False, highlight=False)
+            console.print(self.formatter.format_result(matches), markup=False, highlight=False)
             return None
 
         ignored_matches = [match for match in matches if match.ignored]
@@ -72,7 +72,7 @@ def choose_formatter_factory(
         r = formatters.ParseableFormatter
     elif options_list.parseable_severity:
         r = formatters.ParseableSeverityFormatter
-    elif options_list.parseable_codeclimate:
+    elif options_list.format == 'codeclimate':
         r = formatters.CodeclimateJSONFormatter
     return r
 

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -28,6 +28,12 @@ class App:
 
     def render_matches(self, matches: List) -> None:
         """Display given matches."""
+        if isinstance(self.formatter, formatters.CodeclimateJSONFormatter):
+            # If formatter CodeclimateJSONFormatter is chosen, 
+            # then print only the matches in JSON
+            console.print(self.formatter.format(matches), markup=False, highlight=False)
+            return None
+
         ignored_matches = [match for match in matches if match.ignored]
         fatal_matches = [match for match in matches if not match.ignored]
         # Displayed ignored matches first
@@ -66,6 +72,8 @@ def choose_formatter_factory(
         r = formatters.ParseableFormatter
     elif options_list.parseable_severity:
         r = formatters.ParseableSeverityFormatter
+    elif options_list.parseable_codeclimate:
+        r = formatters.CodeclimateJSONFormatter
     return r
 
 

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -265,7 +265,6 @@ def merge_config(file_config, cli_config: Namespace) -> Namespace:
     bools = (
         'display_relative_path',
         'parseable',
-        'parseable_codeclimate',
         'parseable_severity',
         'quiet',
         'use_default_rules',

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -131,7 +131,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         '-f',
         dest='format',
         default='rich',
-        choices=['rich', 'plain', 'rst'],
+        choices=['rich', 'plain', 'rst', 'codeclimate'],
         help="Format used rules output, (default: %(default)s)",
     )
     parser.add_argument(
@@ -265,6 +265,7 @@ def merge_config(file_config, cli_config: Namespace) -> Namespace:
     bools = (
         'display_relative_path',
         'parseable',
+        'parseable_codeclimate',
         'parseable_severity',
         'quiet',
         'use_default_rules',

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -31,7 +31,6 @@ options = Namespace(
     listtags=False,
     parseable=False,
     parseable_severity=False,
-    parseable_codeclimate=False,
     quiet=False,
     rulesdirs=[],
     skip_list=[],

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -31,6 +31,7 @@ options = Namespace(
     listtags=False,
     parseable=False,
     parseable_severity=False,
+    parseable_codeclimate=False,
     quiet=False,
     rulesdirs=[],
     skip_list=[],

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -149,8 +149,15 @@ class ParseableSeverityFormatter(BaseFormatter):
 
 
 class CodeclimateJSONFormatter(BaseFormatter):
+    """Formatter for emitting violations in Codeclimate JSON report format.
+    Reference: https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-type
+    """
 
     def format(self, matches: List["MatchError"]) -> str:
+
+        if not isinstance(matches, list):
+            raise RuntimeError("The CodeclimatJSONFormatter was expecting a list of MatchError.")
+
         result = []
         for match in matches:
             issue = {}

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -150,17 +150,20 @@ class ParseableSeverityFormatter(BaseFormatter):
 
 class CodeclimateJSONFormatter(BaseFormatter):
     """Formatter for emitting violations in Codeclimate JSON report format.
-    Reference: https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-type
+
+    The formatter expects a list of MatchError objects and returns a JSON formatted string.
+    The spec for the codeclimate report can be found here:
+    https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-type
     """
 
-    def format(self, matches: List["MatchError"]) -> str:
+    def format_result(self, matches: List["MatchError"]) -> str:
 
         if not isinstance(matches, list):
             raise RuntimeError("The CodeclimatJSONFormatter was expecting a list of MatchError.")
 
         result = []
         for match in matches:
-            issue = {}
+            issue: Dict[str, Any] = {}
             issue['type'] = 'issue'
             issue['check_name'] = f"[{match.rule.id}] {match.message}"
             issue['categories'] = match.rule.tags

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -1,9 +1,9 @@
 """Output formatters."""
-import os
-from pathlib import Path
-from typing import TYPE_CHECKING, Generic, TypeVar, Union, List, Dict, Any
 import hashlib
 import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, TypeVar, Union
 
 import rich
 
@@ -159,7 +159,9 @@ class CodeclimateJSONFormatter(BaseFormatter):
     def format_result(self, matches: List["MatchError"]) -> str:
 
         if not isinstance(matches, list):
-            raise RuntimeError("The CodeclimatJSONFormatter was expecting a list of MatchError.")
+            raise RuntimeError(
+                "The CodeclimatJSONFormatter was expecting a list of MatchError."
+            )
 
         result = []
         for match in matches:
@@ -169,7 +171,9 @@ class CodeclimateJSONFormatter(BaseFormatter):
             issue['categories'] = match.rule.tags
             issue['severity'] = self._severity_to_level(match.rule.severity)
             issue['description'] = self.escape(str(match.rule.description))
-            issue['fingerprint'] = hashlib.sha256(repr(match).encode('utf-8')).hexdigest()
+            issue['fingerprint'] = hashlib.sha256(
+                repr(match).encode('utf-8')
+            ).hexdigest()
             issue['location'] = {}
             issue['location']['path'] = self._format_path(match.filename or "")
             issue['location']['lines'] = {}

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -1,7 +1,7 @@
 """Output formatters."""
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, TypeVar, Union, List
+from typing import TYPE_CHECKING, Generic, TypeVar, Union, List, Dict, Any
 import hashlib
 import json
 

--- a/test/TestCodeclimateJSONFormatter.py
+++ b/test/TestCodeclimateJSONFormatter.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2016 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
+import pathlib
+import json
+import unittest
+
+from ansiblelint.errors import MatchError
+from ansiblelint.formatters import CodeclimateJSONFormatter
+from ansiblelint.rules import AnsibleLintRule
+
+
+class TestCodeclimateJSONFormatter(unittest.TestCase):
+
+    def setUp(self):
+        self.rule = AnsibleLintRule()
+        self.rule.id = "TCF0001"
+        self.matches = []
+        self.matches.append(MatchError(
+            message="message",
+            linenumber=1,
+            details="hello",
+            filename="filename.yml",
+            rule=self.rule
+        ))
+        self.matches.append(MatchError(
+            message="message",
+            linenumber=2,
+            details="hello",
+            filename="filename.yml",
+            rule=self.rule
+        ))
+        self.formatter = CodeclimateJSONFormatter(pathlib.Path.cwd(), display_relative_path=True)
+
+    def test_format_list(self):
+        self.formatter.format(self.matches)
+
+    def test_result_is_json(self):
+        json.loads(self.formatter.format(self.matches))
+
+    def test_single_match(self):
+        with self.assertRaises(RuntimeError):
+            self.formatter.format(self.matches[0])

--- a/test/TestCodeclimateJSONFormatter.py
+++ b/test/TestCodeclimateJSONFormatter.py
@@ -1,5 +1,8 @@
-import pathlib
+"""Test the codeclimate JSON formatter."""
 import json
+import pathlib
+from typing import List, Optional
+
 import pytest
 
 from ansiblelint.errors import MatchError
@@ -8,49 +11,60 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class TestCodeclimateJSONFormatter:
+    """Unit test for CodeclimateJSONFormatter."""
+
+    rule = AnsibleLintRule()
+    matches: List[MatchError] = []
+    formatter: Optional[CodeclimateJSONFormatter] = None
 
     def setup_class(self):
-        """Sets up few dummy matcherror objects."""
+        """Set up few MatchError objects."""
         self.rule = AnsibleLintRule()
         self.rule.id = "TCF0001"
         self.rule.severity = "VERY_HIGH"
         self.matches = []
-        self.matches.append(MatchError(
-            message="message",
-            linenumber=1,
-            details="hello",
-            filename="filename.yml",
-            rule=self.rule
-        ))
-        self.matches.append(MatchError(
-            message="message",
-            linenumber=2,
-            details="hello",
-            filename="filename.yml",
-            rule=self.rule
-        ))
-        self.formatter = CodeclimateJSONFormatter(pathlib.Path.cwd(), display_relative_path=True)
+        self.matches.append(
+            MatchError(
+                message="message",
+                linenumber=1,
+                details="hello",
+                filename="filename.yml",
+                rule=self.rule,
+            )
+        )
+        self.matches.append(
+            MatchError(
+                message="message",
+                linenumber=2,
+                details="hello",
+                filename="filename.yml",
+                rule=self.rule,
+            )
+        )
+        self.formatter = CodeclimateJSONFormatter(
+            pathlib.Path.cwd(), display_relative_path=True
+        )
 
     def test_format_list(self):
-        """Tests if the return value is a string"""
+        """Test if the return value is a string."""
         assert isinstance(self.formatter.format_result(self.matches), str)
 
     def test_result_is_json(self):
-        """Tests if returnd string value is a JSON"""
+        """Test if returned string value is a JSON."""
         json.loads(self.formatter.format_result(self.matches))
 
     def test_single_match(self):
-        """Only lists are allowed. Otherwise a RuntimeError will be raised"""
+        """Test negative case. Only lists are allowed. Otherwise a RuntimeError will be raised."""
         with pytest.raises(RuntimeError):
             self.formatter.format_result(self.matches[0])
 
     def test_result_is_list(self):
-        """Tests if the return JSON contains a list with a length of 2"""
+        """Test if the return JSON contains a list with a length of 2."""
         result = json.loads(self.formatter.format_result(self.matches))
         assert len(result) == 2
 
     def test_validate_codeclimate_schema(self):
-        """Tests if the returned JSON is a valid codeclimate report"""
+        """Test if the returned JSON is a valid codeclimate report."""
         result = json.loads(self.formatter.format_result(self.matches))
         single_match = result[0]
         assert 'type' in single_match

--- a/test/TestCodeclimateJSONFormatter.py
+++ b/test/TestCodeclimateJSONFormatter.py
@@ -9,8 +9,8 @@ from ansiblelint.rules import AnsibleLintRule
 
 class TestCodeclimateJSONFormatter:
 
-    @classmethod
     def setup_class(self):
+        """Sets up few dummy matcherror objects."""
         self.rule = AnsibleLintRule()
         self.rule.id = "TCF0001"
         self.rule.severity = "VERY_HIGH"
@@ -32,20 +32,25 @@ class TestCodeclimateJSONFormatter:
         self.formatter = CodeclimateJSONFormatter(pathlib.Path.cwd(), display_relative_path=True)
 
     def test_format_list(self):
+        """Tests if the return value is a string"""
         assert isinstance(self.formatter.format_result(self.matches), str)
 
     def test_result_is_json(self):
+        """Tests if returnd string value is a JSON"""
         json.loads(self.formatter.format_result(self.matches))
 
     def test_single_match(self):
+        """Only lists are allowed. Otherwise a RuntimeError will be raised"""
         with pytest.raises(RuntimeError):
             self.formatter.format_result(self.matches[0])
 
     def test_result_is_list(self):
+        """Tests if the return JSON contains a list with a length of 2"""
         result = json.loads(self.formatter.format_result(self.matches))
         assert len(result) == 2
 
     def test_validate_codeclimate_schema(self):
+        """Tests if the returned JSON is a valid codeclimate report"""
         result = json.loads(self.formatter.format_result(self.matches))
         single_match = result[0]
         assert 'type' in single_match

--- a/test/TestCodeclimateJSONFormatter.py
+++ b/test/TestCodeclimateJSONFormatter.py
@@ -1,37 +1,19 @@
-# Copyright (c) 2016 Will Thames <will@thames.id.au>
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-725
 import pathlib
 import json
-import unittest
+import pytest
 
 from ansiblelint.errors import MatchError
 from ansiblelint.formatters import CodeclimateJSONFormatter
 from ansiblelint.rules import AnsibleLintRule
 
 
-class TestCodeclimateJSONFormatter(unittest.TestCase):
+class TestCodeclimateJSONFormatter:
 
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
         self.rule = AnsibleLintRule()
         self.rule.id = "TCF0001"
+        self.rule.severity = "VERY_HIGH"
         self.matches = []
         self.matches.append(MatchError(
             message="message",
@@ -50,11 +32,33 @@ class TestCodeclimateJSONFormatter(unittest.TestCase):
         self.formatter = CodeclimateJSONFormatter(pathlib.Path.cwd(), display_relative_path=True)
 
     def test_format_list(self):
-        self.formatter.format(self.matches)
+        assert isinstance(self.formatter.format_result(self.matches), str)
 
     def test_result_is_json(self):
-        json.loads(self.formatter.format(self.matches))
+        json.loads(self.formatter.format_result(self.matches))
 
     def test_single_match(self):
-        with self.assertRaises(RuntimeError):
-            self.formatter.format(self.matches[0])
+        with pytest.raises(RuntimeError):
+            self.formatter.format_result(self.matches[0])
+
+    def test_result_is_list(self):
+        result = json.loads(self.formatter.format_result(self.matches))
+        assert len(result) == 2
+
+    def test_validate_codeclimate_schema(self):
+        result = json.loads(self.formatter.format_result(self.matches))
+        single_match = result[0]
+        assert 'type' in single_match
+        assert single_match['type'] == 'issue'
+        assert 'check_name' in single_match
+        assert 'categories' in single_match
+        assert isinstance(single_match['categories'], list)
+        assert 'severity' in single_match
+        assert single_match['severity'] == 'blocker'
+        assert 'description' in single_match
+        assert 'fingerprint' in single_match
+        assert 'location' in single_match
+        assert 'path' in single_match['location']
+        assert single_match['location']['path'] == self.matches[0].filename
+        assert 'lines' in single_match['location']
+        assert single_match['location']['lines']['begin'] == self.matches[0].linenumber


### PR DESCRIPTION
I have introduced a new parameter called `--parseable-codeclimate`. This flag will indicate ansible-lint to use the new formatter CodeclimateJSONFormatter. It will export the matcherror results in JSON following the [Codeclimate spec](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-type). To test this formatter I have created few additional unit test cases. The formatter expects a list of MatchError objects instead of a single MatchError Object.

Example output with the existing formatter ParseableSeverityFormatter
```bash
vagrant@ubuntu-focal:/vagrant/src$ python3 -m ansiblelint --parseable-severity hello.yml
Added ANSIBLE_LIBRARY=.cache/modules
Added ANSIBLE_ROLES_PATH=.cache/roles
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: hello.yml
WARNING  Listing 6 violation(s) that are fatal
hello.yml:7: [YAML] [VERY_LOW] too many blank lines (3 > 2)
hello.yml:8: [YAML] [VERY_LOW] trailing spaces
hello.yml:11: [206] [LOW] Variables should have spaces before and after: {{bla}}
hello.yml:13: [206] [LOW] Variables should have spaces before and after: {{bla}}
hello.yml:13: [301] [HIGH] Commands should not change things if nothing needs doing
hello.yml:13: [502] [MEDIUM] All tasks should be named
You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - '206'  # Variables should have spaces before and after:  {{ var_name }}
  - '301'  # Commands should not change things if nothing needs doing
  - '502'  # All tasks should be named
  - 'YAML'  # Violations reported by yamllint
  - experimental  # all rules tagged as experimental
Finished with 6 failure(s), 0 warning(s) on 1 files.
```

Example output with the new formatter CodeclimateJSONFormatter.
```bash
vagrant@ubuntu-focal:/vagrant/src$ python3 -m ansiblelint --parseable-codeclimate hello.yml
Added ANSIBLE_LIBRARY=.cache/modules
Added ANSIBLE_ROLES_PATH=.cache/roles
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: hello.yml
[{"type": "issue", "check_name": "[YAML] too many blank lines (3 > 2)", "categories": ["formatting", "experimental", "yamllint"], "severity": "info", "description": "Rule violations reported by YamlLint when this is installed.\n\nYou can fully disable all of them by adding 'YAML' to the 'skip_list'.\n\nSpecific tag identifiers that are printed at the end of rule name,\nlike 'trailing-spaces' or 'indentation' can also be be skipped, allowing\nyou to have a more fine control.\n", "fingerprint": "b0851e41d26992bf39ebd1d1a87f8249f4894aba363f9e910feae4d1b3085115", "location": {"path": "hello.yml", "lines": {"begin": 7}}}, {"type": "issue", "check_name": "[YAML] trailing spaces", "categories": ["formatting", "experimental", "yamllint"], "severity": "info", "description": "Rule violations reported by YamlLint when this is installed.\n\nYou can fully disable all of them by adding 'YAML' to the 'skip_list'.\n\nSpecific tag identifiers that are printed at the end of rule name,\nlike 'trailing-spaces' or 'indentation' can also be be skipped, allowing\nyou to have a more fine control.\n", "fingerprint": "e65977880f088335e900ec47400d8ae03436c18bb7066c011ac64a07b9058e34", "location": {"path": "hello.yml", "lines": {"begin": 8}}}, {"type": "issue", "check_name": "[206] Variables should have spaces before and after: {{bla}}", "categories": ["formatting"], "severity": "minor", "description": "Variables should have spaces before and after: ``{{ var_name }}``", "fingerprint": "1b0c8063e5bd49994fea26f25dc96286b44542884f8e3324e5347fb29cd1fdae", "location": {"path": "hello.yml", "lines": {"begin": 11}}, "content": {"body": "Task/Handler: debug msg={{bla}}"}}, {"type": "issue", "check_name": "[206] Variables should have spaces before and after: {{bla}}", "categories": ["formatting"], "severity": "minor", "description": "Variables should have spaces before and after: ``{{ var_name }}``", "fingerprint": "81fec0f931a0895bca0141a9137fe37c71700b5b81baf663d0bdda38d593b4ce", "location": {"path": "hello.yml", "lines": {"begin": 13}}, "content": {"body": "Task/Handler: command  echo {{bla}}"}}, {"type": "issue", "check_name": "[301] Commands should not change things if nothing needs doing", "categories": ["command-shell", "idempotency"], "severity": "critical", "description": "Commands should either read information (and thus set ``changed_when``) or not do something if it has already been done (using creates/removes) or only do it if another check has a particular result (``when``)", "fingerprint": "d57fbb328371a4c6ae1d54141df55f1b778aaaef8da75b13e2fdd73b3cda5dae", "location": {"path": "hello.yml", "lines": {"begin": 13}}, "content": {"body": "Task/Handler: command  echo {{bla}}"}}, {"type": "issue", "check_name": "[502] All tasks should be named", "categories": ["task", "readability"], "severity": "major", "description": "All tasks should have a distinct name for readability and for ``--start-at-task`` to work", "fingerprint": "943dffb61e26499b71e10a95197833b159e48bfc6eebef8f23adaf9b37eafc0d", "location": {"path": "hello.yml", "lines": {"begin": 13}}, "content": {"body": "Task/Handler: command  echo {{bla}}"}}]
You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - '206'  # Variables should have spaces before and after:  {{ var_name }}
  - '301'  # Commands should not change things if nothing needs doing
  - '502'  # All tasks should be named
  - 'YAML'  # Violations reported by yamllint
  - experimental  # all rules tagged as experimental
Finished with 6 failure(s), 0 warning(s) on 1 files.
```