### PR TITLE
Fix parsing of unicode filenames reported by git ls-files (#1339)

### DIFF
--- a/examples/playbooks/with-umlaut-ä.yml
+++ b/examples/playbooks/with-umlaut-ä.yml
@@ -1,0 +1,5 @@
+---
+- hosts:
+  - localhost
+  roles:
+  - name: node

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -166,7 +166,7 @@ class Lintable:
 def get_yaml_files(options: Namespace) -> Dict[str, Any]:
     """Find all yaml files."""
     # git is preferred as it also considers .gitignore
-    git_command = ['git', 'ls-files', '*.yaml', '*.yml']
+    git_command = ['git', 'ls-files', '-z', '*.yaml', '*.yml']
     _logger.info("Discovering files to lint: %s", ' '.join(git_command))
 
     out = None
@@ -174,7 +174,7 @@ def get_yaml_files(options: Namespace) -> Dict[str, Any]:
     try:
         out = subprocess.check_output(
             git_command, stderr=subprocess.STDOUT, universal_newlines=True
-        ).splitlines()
+        ).split("\x00")[:-1]
     except subprocess.CalledProcessError as exc:
         _logger.warning(
             "Failed to discover yaml files to lint using git: %s",

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -98,12 +98,11 @@ def run_ansible_lint(
 
     if env is None:
         _env = {}
-        for v in safe_list:
-            if v in os.environ:
-                _env[v] = os.environ[v]
-
     else:
         _env = env
+    for v in safe_list:
+        if v in os.environ and v not in _env:
+            _env[v] = os.environ[v]
 
     return subprocess.run(
         args,


### PR DESCRIPTION
I fixed German umlauts in filenames by changing this
```
git ls-files '*.yaml' '*.yml'
```
to this
```
git ls-files -z '*.yaml' '*.yml'
```
The output in not delimited by newlines but by `\0` instead. So I also had to change the output parsing.

A test case is included.