### PR TITLE
support extra_vars in syntax check rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -38,5 +38,9 @@ warn_list:
   - git-latest
   - experimetal  # experimental is included in the implicit list
 
-# offline mode disables installation of requirements.yml
+# Offline mode disables installation of requirements.yml
 offline: false
+
+# Define required Ansible's variables to satisfy syntax check
+extra_vars:
+  - foo: bar

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -44,3 +44,7 @@ offline: false
 # Define required Ansible's variables to satisfy syntax check
 extra_vars:
   foo: bar
+  multiline_string_variable: |
+    line1
+    line2
+  complex_variable: ":{;\t$()"

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -43,4 +43,4 @@ offline: false
 
 # Define required Ansible's variables to satisfy syntax check
 extra_vars:
-  - foo: bar
+  foo: bar

--- a/examples/playbooks/custom_module.yml
+++ b/examples/playbooks/custom_module.yml
@@ -1,5 +1,7 @@
 - hosts: localhost
   gather_facts: false
+  tags:
+    - "{{ foo }}"
   tasks:
     - name: Run custom module
       fake_module: {}

--- a/examples/playbooks/extra_vars.yml
+++ b/examples/playbooks/extra_vars.yml
@@ -3,3 +3,7 @@
   tags:
     - baz
     - "{{ foo }}"
+  tasks:
+    - name: Show `complex_variable` value loaded from `extra_vars`
+      ansible.builtin.debug:
+        msg: "{{ complex_variable }}"

--- a/examples/playbooks/extra_vars.yml
+++ b/examples/playbooks/extra_vars.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  tags:
+    - baz
+    - "{{ foo }}"

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -50,6 +50,7 @@ options = Namespace(
     mock_roles=[],
     loop_var_prefix=None,
     offline=False,
+    extra_vars=None,
 )
 
 # Used to store detected tag deprecations

--- a/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
+++ b/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
@@ -143,8 +143,10 @@ if "pytest" in sys.modules:
 
     def test_extra_vars_passed_to_command(config_options) -> None:
         """Validate `extra-vars` are passed to syntax check command."""
-        config_options.extra_vars = {'foo': 'bar', 'additional_var': 'test'}
-        print(options, config_options, options == config_options)
+        config_options.extra_vars = {
+            'foo': 'bar',
+            'complex_variable': ':{;\t$()',
+        }
         lintable = Lintable('examples/playbooks/extra_vars.yml', kind='playbook')
 
         result = AnsibleSyntaxCheckRule._get_ansible_syntax_check_matches(lintable)

--- a/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
+++ b/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
@@ -1,10 +1,12 @@
 """Rule definition for ansible syntax check."""
+import json
 import re
 import subprocess
 import sys
 from typing import List
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
+from ansiblelint.config import options
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.logger import timed_info
@@ -39,7 +41,15 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
             return []
 
         with timed_info("Executing syntax check on %s", lintable.path):
-            cmd = ['ansible-playbook', '--syntax-check', str(lintable.path)]
+            extra_vars_cmd = []
+            if options.extra_vars:
+                extra_vars_cmd = ['--extra-vars', json.dumps(options.extra_vars)]
+            cmd = [
+                'ansible-playbook',
+                '--syntax-check',
+                *extra_vars_cmd,
+                str(lintable.path),
+            ]
             run = subprocess.run(
                 cmd,
                 stdin=subprocess.PIPE,
@@ -130,3 +140,13 @@ if "pytest" in sys.modules:
         assert result[0].tag == "empty-playbook"
         assert result[0].message == "Empty playbook, nothing to do"
         assert len(result) == 1
+
+    def test_extra_vars_passed_to_command(config_options) -> None:
+        """Validate `extra-vars` are passed to syntax check command."""
+        config_options.extra_vars = {'foo': 'bar', 'additional_var': 'test'}
+        print(options, config_options, options == config_options)
+        lintable = Lintable('examples/playbooks/extra_vars.yml', kind='playbook')
+
+        result = AnsibleSyntaxCheckRule._get_ansible_syntax_check_matches(lintable)
+
+        assert not result

--- a/src/ansiblelint/testing/fixtures.py
+++ b/src/ansiblelint/testing/fixtures.py
@@ -5,10 +5,12 @@ file:
 
 pytest_plugins = ['ansiblelint.testing']
 """
+import copy
 import os
 
 import pytest
 
+from ansiblelint.config import options  # noqa: F401
 from ansiblelint.constants import DEFAULT_RULESDIR
 from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
@@ -48,6 +50,15 @@ def rule_runner(request):
     collection = RulesCollection()
     collection.register(rule_class())
     return RunFromText(collection)
+
+
+@pytest.fixture
+def config_options():
+    """Return configuration options that will be restored after testrun."""
+    global options  # pylint: disable=global-statement
+    original_options = copy.deepcopy(options)
+    yield options
+    options = original_options
 
 
 @pytest.fixture


### PR DESCRIPTION
Adds ability to define a set of extra vars to be passed to ansible when we call `--syntax-check`, so we can avoid failures caused by them.

Closes: #1299 
