### PR TITLE
Ensure that yamllint config ignore entries are used

### DIFF
--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -80,7 +80,9 @@ class YamllintRule(AnsibleLintRule):
             return matches
 
         if YamllintRule.config:
-            for p in run_yamllint(file.content, YamllintRule.config, filepath=file.path):
+            for p in run_yamllint(
+                file.content, YamllintRule.config, filepath=file.path
+            ):
                 matches.append(
                     self.create_matcherror(
                         message=p.desc,

--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -63,6 +63,7 @@ class YamllintRule(AnsibleLintRule):
                 )
                 config_override = YamlLintConfig(file=file)
                 config_override.extend(config)
+                config = config_override
                 break
         _logger.debug("Effective yamllint rules used: %s", config.rules)
 
@@ -79,7 +80,7 @@ class YamllintRule(AnsibleLintRule):
             return matches
 
         if YamllintRule.config:
-            for p in run_yamllint(file.content, YamllintRule.config):
+            for p in run_yamllint(file.content, YamllintRule.config, filepath=file.path):
                 matches.append(
                     self.create_matcherror(
                         message=p.desc,

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -1,18 +1,20 @@
 """Assure samples produced desire outcomes."""
 import os
+
 import pytest
 
 from ansiblelint.runner import Runner
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def _change_into_examples_dir(request):
     os.chdir('examples')
     yield
     os.chdir('..')
 
 
-def test_example(default_rules_collection, _change_into_examples_dir):
+@pytest.mark.usefixtures('_change_into_examples_dir')
+def test_example(default_rules_collection):
     """example.yml is expected to have 15 match errors inside."""
     result = Runner('playbooks/example.yml', rules=default_rules_collection).run()
     assert len(result) == 15

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -1,14 +1,20 @@
 """Assure samples produced desire outcomes."""
+import os
 import pytest
 
 from ansiblelint.runner import Runner
 
 
-def test_example(default_rules_collection):
+@pytest.fixture(scope="function")
+def _change_into_examples_dir(request):
+    os.chdir('examples')
+    yield
+    os.chdir('..')
+
+
+def test_example(default_rules_collection, _change_into_examples_dir):
     """example.yml is expected to have 15 match errors inside."""
-    result = Runner(
-        'examples/playbooks/example.yml', rules=default_rules_collection
-    ).run()
+    result = Runner('playbooks/example.yml', rules=default_rules_collection).run()
     assert len(result) == 15
 
 


### PR DESCRIPTION
There are two problems why `ignore` entries were ignored:
1. The way `YamlLintConfig.extend()` works with `ignore` entries, it is important to use the extended config instead of the original one.
2. The path needs to be supplied to `run()` so that yamllint can process its `ignore` config entries.

Fixes: #1344