### PR TITLE
Adds experimental stdin support

### DIFF
--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -91,11 +91,11 @@ class AnsibleLintRule(BaseRule):
         if not self.matchtask or file.kind == 'meta':
             return matches
 
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(file.content, file.path)
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(file)
         if not yaml:
             return matches
 
-        yaml = append_skipped_rules(yaml, file.content, file.kind)
+        yaml = append_skipped_rules(yaml, file)
 
         try:
             tasks = ansiblelint.utils.get_normalized_tasks(yaml, file)
@@ -138,7 +138,7 @@ class AnsibleLintRule(BaseRule):
         if not self.matchplay:
             return matches
 
-        yaml = ansiblelint.utils.parse_yaml_linenumbers(file.content, file.path)
+        yaml = ansiblelint.utils.parse_yaml_linenumbers(file)
         # yaml returned can be an AnsibleUnicode (a string) when the yaml
         # file contains a single string. YAML spec allows this but we consider
         # this an fatal error.
@@ -150,9 +150,7 @@ class AnsibleLintRule(BaseRule):
         if isinstance(yaml, dict):
             yaml = [yaml]
 
-        yaml = ansiblelint.skip_utils.append_skipped_rules(
-            yaml, file.content, file.kind
-        )
+        yaml = ansiblelint.skip_utils.append_skipped_rules(yaml, file)
 
         for play in yaml:
 

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -99,7 +99,7 @@ def test_runner_with_directory(default_rules_collection, directory_name) -> None
 
 
 def test_files_not_scanned_twice(default_rules_collection) -> None:
-    checked_files: Set[str] = set()
+    checked_files: Set[Lintable] = set()
 
     filename = os.path.abspath('examples/playbooks/common-include-1.yml')
     runner = Runner(


### PR DESCRIPTION
Allow ansible-lint to perform linting from stdin when filename arguments as `/dev/stdin` or `-` are given.

Keep in mind:
- no argument still means auto-detect as I found no reliable way to identify that the tool was used with shell pipes
- filename reported is 'stdin', same as flake8 does
- received content is assumed to be a playbook, you cannot lint a task file this way. Others are welcomed to propose improvements for detecting the file type based on its content, because we do not have any `filename` available.

Fixes: #790