### PR TITLE
Fix file config extra_vars options loading

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -300,11 +300,11 @@ def merge_config(file_config, cli_config: Namespace) -> Namespace:
         return cli_config
 
     for entry in bools:
-        x = getattr(cli_config, entry) or file_config.get(entry, False)
+        x = getattr(cli_config, entry) or file_config.pop(entry, False)
         setattr(cli_config, entry, x)
 
     for entry, default in scalar_map.items():
-        x = getattr(cli_config, entry, None) or file_config.get(entry, default)
+        x = getattr(cli_config, entry, None) or file_config.pop(entry, default)
         setattr(cli_config, entry, x)
 
     # if either commandline parameter or config file option is set merge
@@ -312,13 +312,17 @@ def merge_config(file_config, cli_config: Namespace) -> Namespace:
     for entry, default in lists_map.items():
         if getattr(cli_config, entry, None) or entry in file_config.keys():
             value = getattr(cli_config, entry, [])
-            value.extend(file_config.get(entry, []))
+            value.extend(file_config.pop(entry, []))
         else:
             value = default
         setattr(cli_config, entry, value)
 
     if 'verbosity' in file_config:
-        cli_config.verbosity = cli_config.verbosity + file_config['verbosity']
+        cli_config.verbosity = cli_config.verbosity + file_config.pop('verbosity')
+
+    # merge options that can be set only via a file config
+    for entry, value in file_config.items():
+        setattr(cli_config, entry, value)
 
     return cli_config
 

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -134,3 +134,12 @@ def test_config_failure(base_arguments, config_file):
     """Ensures specific config files produce error code 2."""
     with pytest.raises(SystemExit, match="^2$"):
         cli.get_config(base_arguments + ["-c", config_file])
+
+
+def test_extra_vars_loaded(base_arguments):
+    """Ensure ``extra_vars`` option is loaded from file config."""
+    config = cli.get_config(
+        base_arguments + ["-c", "test/fixtures/config-with-extra-vars.yml"]
+    )
+
+    assert config.extra_vars == {'foo': 'bar', 'knights_favorite_word': 'NI'}

--- a/test/fixtures/config-with-extra-vars.yml
+++ b/test/fixtures/config-with-extra-vars.yml
@@ -1,0 +1,4 @@
+---
+extra_vars:
+  foo: bar
+  knights_favorite_word: NI


### PR DESCRIPTION
In #1342 `extra_vars` option was added to the file config, but it's not properly loaded (sorry, I should add a test for this in the before-mentioned PR :disappointed:).
This PR fixes `extra_vars` option loading by updating `merge_config` function - now all file config options that wasn't declared in `bool`, `scalar_map` or `lists_map` variable are merged into `cli_config`.