### PR TITLE
Disable action validation with tasks by default

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -48,3 +48,7 @@ extra_vars:
     line1
     line2
   complex_variable: ":{;\t$()"
+
+# Uncomment to enforce action validation with tasks, usually is not
+# needed as Ansible syntax check also covers it.
+# skip_action_validation: false

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -54,6 +54,7 @@ options = Namespace(
     loop_var_prefix=None,
     offline=False,
     extra_vars=None,
+    skip_action_validation=True,
 )
 
 # Used to store detected tag deprecations

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -60,6 +60,7 @@ from ansiblelint._internal.rules import (
     LoadingFailureRule,
     RuntimeErrorRule,
 )
+from ansiblelint.config import options
 from ansiblelint.constants import FileType
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable, get_yaml_files
@@ -516,7 +517,9 @@ def normalize_task_v2(task: Dict[str, Any]) -> Dict[str, Any]:
     sanitized_task = _sanitize_task(task)
     mod_arg_parser = ModuleArgsParser(sanitized_task)
     try:
-        action, arguments, result['delegate_to'] = mod_arg_parser.parse()
+        action, arguments, result['delegate_to'] = mod_arg_parser.parse(
+            skip_action_validation=options.skip_action_validation
+        )
     except AnsibleParserError as e:
         raise MatchError(
             rule=AnsibleParserErrorRule(),


### PR DESCRIPTION
This change should address mentioned bug by introducing a small risk of not catching some invalid module calls for roles that do not have playbooks inside the same repository.

All users that have at least one playbook that imports the role, will still be able to detect these errors as ansible-playbook --syntax-check finds them.

We plan to add a feature that would create fake temporary playbooks for roles found inside a repository, ones that would help us identify missing or misspelled modules.

Fixes: #1354