### PR TITLE
Disable dependabot due to spammy nature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Until bug below is sorted we will not allow dependabot to run by itself
+# https://github.com/dependabot/dependabot-core/issues/369
 version: 2
 updates:
 - package-ecosystem: pip
@@ -9,7 +11,7 @@ updates:
   - dependabot-deps-updates
   - skip-changelog
   versioning-strategy: lockfile-only
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 0  # neutered
 - package-ecosystem: pip
   directory: /
   schedule:
@@ -19,4 +21,4 @@ updates:
   - dependabot-deps-updates
   - skip-changelog
   versioning-strategy: lockfile-only
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 0  # neutered


### PR DESCRIPTION
Disable dependabot as it proves to only spam the project with updates on each dependency. Until they manage to produce consolidated pull-requests, we are better of doing it manually.

After being bullied by dependabot waves of pull-requests for few months is time to neuter it. Clearly its current design does not work well with projects that have many dependencies and especially

![](https://sbarnea.com/ss/Screen-Shot-2021-02-21-10-45-24.45.png)

Related: https://github.com/dependabot/dependabot-core/issues/369
