### PR TITLE
Made output formatting options more consistent

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -68,9 +68,9 @@ def choose_formatter_factory(
 ) -> Type[formatters.BaseFormatter]:
     """Select an output formatter based on the incoming command line arguments."""
     r: Type[formatters.BaseFormatter] = formatters.Formatter
-    if options_list.quiet:
+    if options_list.format == 'quiet':
         r = formatters.QuietFormatter
-    elif options_list.parseable:
+    elif options_list.parseable or options_list.format == 'pep8':
         r = formatters.ParseableFormatter
     elif options_list.parseable_severity:
         r = formatters.ParseableSeverityFormatter

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -131,7 +131,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         '-f',
         dest='format',
         default='rich',
-        choices=['rich', 'plain', 'rst', 'codeclimate'],
+        choices=['rich', 'plain', 'rst', 'codeclimate', 'quiet', 'pep8'],
         help="Format used rules output, (default: %(default)s)",
     )
     parser.add_argument(
@@ -146,7 +146,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         dest='parseable',
         default=False,
         action='store_true',
-        help="parseable output in the format of pep8",
+        help="parseable output, same as '-f pep8'",
     )
     parser.add_argument(
         '--parseable-severity',

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, List, TypeVar, Union
 
 import rich
 
+from ansiblelint.config import options
+
 if TYPE_CHECKING:
     from ansiblelint.errors import MatchError
 
@@ -84,8 +86,12 @@ class ParseableFormatter(BaseFormatter):
     def format(self, match: "MatchError") -> str:
         result = (
             f"[filename]{self._format_path(match.filename or '')}[/]:{match.position}: "
-            f"[error_code]{match.rule.id}[/] [dim]{self.escape(match.message)}[/]"
+            f"[error_code]{match.rule.id}[/]"
         )
+
+        if not options.quiet:
+            result += f" [dim]{match.message}[/]"
+
         if match.tag:
             result += f" [dim][error_code]({match.tag})[/][/]"
         return result


### PR DESCRIPTION
- Quiet formatter is now triggered with `-f quiet` instead of `-q`, which can affect other formatters and logging
- When called with `-p -q`, we no longer print the full rule message, only its short code and tags.

This fixes bug where the output format was totally changed by the simple addition of the `-q` parameter, which is usually used to lower the verbosity levels.