### PR TITLE
Add yes and no to truthy check in yamllint

### DIFF
--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -24,6 +24,8 @@ YAMLLINT_CONFIG = """
 extends: default
 rules:
   document-start: disable
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no']
   # 160 chars was the default used by old E204 rule, but
   # you can easily change it or disable in your .yamllint file.
   line-length:


### PR DESCRIPTION
### Description

When running `ansible-lint` with `yamllint` installed, `ansible-lint` will complain about the use of the unqouted `yes` and `no` boolean values. However, [`yes` and `no` are accepted boolean values by Ansible](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html).

This PR adds `yes` and `no` to the accepted boolean list.

[Ansible accepts a lot more values as boolean values](https://github.com/ansible/ansible/blob/c22bc46cb960ade62ea9bad240a2ae0cd3a17582/lib/ansible/module_utils/parsing/convert_bool.py#L11-L12). If anyone wants it, I can add the other strings as well. 