### PR TITLE
only warn about failing git discovery when increased verbosity level

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -197,10 +197,11 @@ def get_yaml_files(options: Namespace) -> Dict[str, Any]:
             git_command, stderr=subprocess.STDOUT, universal_newlines=True
         ).split("\x00")[:-1]
     except subprocess.CalledProcessError as exc:
-        _logger.warning(
-            "Failed to discover yaml files to lint using git: %s",
-            exc.output.rstrip('\n'),
-        )
+        if options.verbosity:
+            _logger.warning(
+                "Failed to discover yaml files to lint using git: %s",
+                exc.output.rstrip('\n'),
+            )
     except FileNotFoundError as exc:
         if options.verbosity:
             _logger.warning("Failed to locate command: %s", exc)


### PR DESCRIPTION
```sh
$ ansible-lint test.yml 
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: test.yml
WARNING  Listing 1 violation(s) that are fatal
no-changed-when: Commands should not change things if nothing needs doing
test.yml:7 Task/Handler: Register a command

You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - no-changed-when  # Commands should not change things if nothing needs doing
Finished with 1 failure(s), 0 warning(s) on 1 files.
$ ansible-lint -v test.yml 
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: test.yml
INFO     Discovering files to lint: git ls-files -z *.yaml *.yml
WARNING  Failed to discover yaml files to lint using git: fatal: not a git repository (or any of the parent directories): .git
INFO     Executing syntax check on test.yml (0.78s)
WARNING  Listing 1 violation(s) that are fatal
no-changed-when: Commands should not change things if nothing needs doing
test.yml:7 Task/Handler: Register a command

You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - no-changed-when  # Commands should not change things if nothing needs doing
Finished with 1 failure(s), 0 warning(s) on 1 files.
```

closes #1410

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>