### PR TITLE
Avoid creating .cache directory in cwd

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,19 @@ associated tags.
    :cwd: ..
    :returncode: 0
 
+Temporary files
+---------------
+
+As part of the execution, the linter will likely need to create a cache of
+installed or mocked roles, collections and modules. This is done inside
+``{project_dir}/.cache`` folder. The project directory is either given as a
+command line argument, determined by location of the configuration
+file, git project top-level directiory or user home directory as fallback.
+In order to speed-up reruns, the linter does not clean this folder by itself.
+
+If you are using git, you will likely want to add this folder to your
+``.gitignore`` file by running ``git ignore .cache``.
+
 Progressive mode
 ----------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,7 +34,7 @@ file, git project top-level directiory or user home directory as fallback.
 In order to speed-up reruns, the linter does not clean this folder by itself.
 
 If you are using git, you will likely want to add this folder to your
-``.gitignore`` file by running ``git ignore .cache``.
+``.gitignore`` file.
 
 Progressive mode
 ----------------

--- a/src/ansiblelint/_prerun.py
+++ b/src/ansiblelint/_prerun.py
@@ -99,7 +99,7 @@ def prepare_environment() -> None:
             "role",
             "install",
             "--roles-path",
-            ".cache/roles",
+            f"{options.project_dir}/.cache/roles",
             "-vr",
             "requirements.yml",
         ]
@@ -124,7 +124,7 @@ def prepare_environment() -> None:
                 "collection",
                 "install",
                 "-p",
-                ".cache/collections",
+                f"{options.project_dir}/.cache/collections",
                 "-vr",
                 "requirements.yml",
             ]
@@ -175,7 +175,7 @@ Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
             file=sys.stderr,
         )
         sys.exit(INVALID_PREREQUISITES_RC)
-    p = pathlib.Path(".cache/roles")
+    p = pathlib.Path(f"{options.project_dir}/.cache/roles")
     p.mkdir(parents=True, exist_ok=True)
     link_path = p / f"{role_author}.{role_name}"
     # despite documentation stating that is_file() reports true for symlinks,
@@ -195,10 +195,10 @@ def _prepare_ansible_paths() -> None:
 
     for path_list, path in (
         (library_paths, "plugins/modules"),
-        (library_paths, ".cache/modules"),
-        (collection_list, ".cache/collections"),
+        (library_paths, f"{options.project_dir}/.cache/modules"),
+        (collection_list, f"{options.project_dir}/.cache/collections"),
         (roles_path, "roles"),
-        (roles_path, ".cache/roles"),
+        (roles_path, f"{options.project_dir}/.cache/roles"),
     ):
         if path not in path_list and os.path.exists(path):
             path_list.append(path)
@@ -212,7 +212,7 @@ def _make_module_stub(module_name: str) -> None:
     # a.b.c is treated a collection
     if re.match(r"\w+\.\w+\.\w+", module_name):
         namespace, collection, module_file = module_name.split(".")
-        path = f".cache/collections/ansible_collections/{ namespace }/{ collection }/plugins/modules"
+        path = f"{ options.project_dir }/.cache/collections/ansible_collections/{ namespace }/{ collection }/plugins/modules"
         os.makedirs(path, exist_ok=True)
         _write_module_stub(
             filename=f"{path}/{module_file}.py",
@@ -227,9 +227,10 @@ def _make_module_stub(module_name: str) -> None:
         )
         sys.exit(INVALID_CONFIG_RC)
     else:
-        os.makedirs(".cache/modules", exist_ok=True)
+        os.makedirs(f"{options.project_dir}/.cache/modules", exist_ok=True)
         _write_module_stub(
-            filename=f".cache/modules/{module_name}.py", name=module_name
+            filename=f"{options.project_dir}/.cache/modules/{module_name}.py",
+            name=module_name,
         )
 
 

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -54,6 +54,7 @@ options = Namespace(
     mock_roles=[],
     loop_var_prefix=None,
     offline=False,
+    project_dir=None,
     extra_vars=None,
     skip_action_validation=True,
 )

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -216,6 +216,21 @@ def get_yaml_files(options: Namespace) -> Dict[str, Any]:
     return OrderedDict.fromkeys(sorted(out))
 
 
+def guess_project_dir() -> str:
+    """Return detected project dir or user home directory."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        return str(Path.home())
+    return result.stdout[0]
+
+
 def expand_dirs_in_lintables(lintables: Set[Lintable]) -> None:
     """Return all recognized lintables within given directory."""
     all_files = get_yaml_files(options)

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -108,7 +108,7 @@ class TestCliRolePaths(unittest.TestCase):
         result = run_ansible_lint(role_path, cwd=cwd)
         assert len(result.stdout) == 0
         assert (
-            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles:.cache/roles"
+            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles"
             in result.stderr
         )
         assert result.returncode == 0
@@ -120,7 +120,7 @@ class TestCliRolePaths(unittest.TestCase):
         result = run_ansible_lint(role_path, cwd=cwd)
         assert len(result.stdout) == 0
         assert (
-            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles:.cache/roles"
+            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles"
             in result.stderr
         )
         assert result.returncode == 0

--- a/test/TestCommandLineInvocationSameAsConfig.py
+++ b/test/TestCommandLineInvocationSameAsConfig.py
@@ -44,6 +44,11 @@ def test_ensure_config_are_equal(base_arguments, args, config):
     file_config = cli.load_config(config)
 
     for key, val in file_config.items():
+
+        # config_file does not make sense in file_config
+        if key == 'config_file':
+            continue
+
         if key in {'exclude_paths', 'rulesdir'}:
             val = [Path(p) for p in val]
         assert val == getattr(options, key)


### PR DESCRIPTION
Instead of using cwd for the .cache folder, we now try to use the project_dir for that, which defaults to the location of
.ansiblelint config file.

Running ansible-lint from a subdirectory of the project, should no longer create .cache folders in new locations.

Execution outside a project or a git repository will make the linter use user home directory as reference, 