### PR TITLE
Disable ANSI output during testing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,9 @@
 """PyTest Fixtures."""
+import os
 import re
 import sys
 
+os.environ["NO_COLOR"] = "1"
 pytest_plugins = ["ansiblelint.testing.fixtures"]
 
 

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -90,6 +90,7 @@ def run_ansible_lint(
         'LANG',
         'LC_ALL',
         'LC_CTYPE',
+        'NO_COLOR',
         'PATH',
         'PYTHONIOENCODING',
         'PYTHONPATH',


### PR DESCRIPTION
This makes output of test failures easier to read as they will no longer end-up containing ANSI.