### PR TITLE
Avoid looking for config file outside current git repo

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -15,6 +15,10 @@ file. Ansible-lint checks the working directory for the presence of this file
 and applies any configuration found there. The configuration file location can
 also be overridden via the ``-c path/to/file`` CLI flag.
 
+When configuration file is not found in current directory, the tool will try
+to look for one in parent directories but it will not go outside current git
+repository.
+
 If a value is provided on both the command line and via a config file, the
 values will be merged (if a list like **exclude_paths**), or the **True** value
 will be preferred, in the case of something like **quiet**.

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -109,6 +109,11 @@ def get_config_path(config_file: str = '.ansible-lint') -> Optional[str]:
             filename = os.path.abspath(os.path.join(parent, project_filename))
             if os.path.exists(filename):
                 return filename
+            if os.path.exists(os.path.abspath(os.path.join(parent, '.git'))):
+                # Avoid looking outside .git folders as we do not want endup
+                # picking config files from upper level projects if current
+                # project has no config.
+                return None
         (parent, tail) = os.path.split(parent)
     return None
 


### PR DESCRIPTION
This fixes a bug where running the linter inside a project that did
not had a config file could endup picking a config file from another
project (was happening only when projects were nested).

From now on, we stop looking at parent directories when we encounter
the .git folder, which can be seen as project boundary.