### PR TITLE
Avoid reporting matcherrors against cwd

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -100,7 +100,7 @@ the following:
 If playbooks include other playbooks, or tasks, or handlers or roles, these
 are also handled:
 
-.. command-output:: ansible-lint -p examples/playbooks/include.yml
+.. command-output:: ansible-lint --offline -p examples/playbooks/include.yml
    :cwd: ..
    :returncode: 2
    :nostderr:

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -1,6 +1,5 @@
 """Exceptions and error representations."""
 import functools
-import os
 from typing import Any, Optional, Union
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
@@ -47,13 +46,12 @@ class MatchError(ValueError):
         self.linenumber = linenumber
         self.column = column
         self.details = details
+        self.filename = ""
         if filename:
             if isinstance(filename, Lintable):
                 self.filename = normpath(str(filename.path))
             else:
                 self.filename = normpath(filename)
-        else:
-            self.filename = os.getcwd()
         self.rule = rule
         self.ignored = False  # If set it will be displayed but not counted as failure
         # This can be used by rules that can report multiple errors type, so

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -43,7 +43,7 @@ class BaseFormatter(Generic[T]):
         if isinstance(path, Path):
             path = str(path)  # Drop when Python 3.5 is no longer supported
 
-        if not self._base_dir:
+        if not self._base_dir or not path:
             return path
         # Use os.path.relpath 'cause Path.relative_to() misbehaves
         return os.path.relpath(path, start=self._base_dir)

--- a/src/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/src/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -79,5 +79,4 @@ class MetaMainHasInfoRule(AnsibleLintRule):
                 self.create_matcherror(message=err, filename=file)
                 for err in _galaxy_info_errors_itr(galaxy_info)
             ]
-
-        return [self.create_matcherror(message="No 'galaxy_info' found")]
+        return [self.create_matcherror(message="No 'galaxy_info' found", filename=file)]

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -84,6 +84,9 @@ class Runner:
 
         # Exclusions should be evaluated only using absolute paths in order
         # to work correctly.
+        if not file_path:
+            return False
+
         abs_path = os.path.abspath(file_path)
         _file_path = Path(file_path)
 
@@ -165,6 +168,8 @@ class Runner:
                         self.lintables.add(child)
                         files.append(child)
                 except MatchError as e:
+                    if not e.filename:
+                        e.filename = str(lintable.path)
                     e.rule = LoadingFailureRule()
                     yield e
                 except AttributeError:


### PR DESCRIPTION
Removes the default use of cwd  for filename for matcherrors raised during parsing. In some particular cases the errors would end-up without a valid filename, making hard to find the problem.