### PR TITLE
Improve risky-shell-pipe rule matching

### DIFF
--- a/src/ansiblelint/rules/ShellWithoutPipefail.py
+++ b/src/ansiblelint/rules/ShellWithoutPipefail.py
@@ -2,6 +2,7 @@ import re
 from typing import Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import convert_to_boolean
 
 
 class ShellWithoutPipefail(AnsibleLintRule):
@@ -39,4 +40,5 @@ class ShellWithoutPipefail(AnsibleLintRule):
         return bool(
             self._pipe_re.search(unjinjad_cmd)
             and not self._pipefail_re.match(unjinjad_cmd)
+            and not convert_to_boolean(task['action'].get('ignore_errors', False))
         )

--- a/test/TestShellWithoutPipefail.py
+++ b/test/TestShellWithoutPipefail.py
@@ -65,6 +65,10 @@ SUCCESS_TASKS = '''
     - shell: |
         set -o pipefail
         df | grep '/dev'
+
+    - name: should not fail due to ignore_errors being true
+      shell: false | cat
+      ignore_errors: true
 '''
 
 


### PR DESCRIPTION
Removes one false positive case where user set `ignore_errors: true`, case in which the rule does not make much sense.

Fixes: #1250