### PR TITLE
fix: flake8 error on mocked modules

### DIFF
--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -43,6 +43,7 @@ author:
 EXAMPLES = '''mocked'''
 RETURN = '''mocked'''
 
+
 def main():
     result = dict(
         changed=False,


### PR DESCRIPTION
This fixes a flake8 error when running flake8 on the .cache folder. This happens when you don't specifically specify what files to flake8. flake8 will automatically pick up the file. The error it throws is this:
```
✗ flake8 --format=pylint --output-file=flake8.log
./.cache/modules/my_awesome_module.py:17: [E302] expected 2 blank lines, found 1
```

Cheers,