### PR TITLE
Allow user to extend kinds without overriding defaults

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -59,3 +59,13 @@ extra_vars:
 # Uncomment to enforce action validation with tasks, usually is not
 # needed as Ansible syntax check also covers it.
 # skip_action_validation: false
+
+# List of additional kind:pattern to be added at the top of the default
+# match list, first match determines the file kind.
+kinds:
+  # - playbook: "**/examples/*.{yml,yaml}"
+  # - galaxy: "**/folder/galaxy.yml"
+  # - tasks: "**/tasks/*.yml"
+  # - vars: "**/vars/*.yml"
+  # - meta: "**/meta/main.yml"
+  - yaml: "**/*.yaml-too"

--- a/examples/other/some.yaml-too
+++ b/examples/other/some.yaml-too
@@ -1,0 +1,1 @@
+# Used to test custom kinds defined in .ansible-config

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 import yaml
 
+from ansiblelint.config import DEFAULT_KINDS
 from ansiblelint.constants import (
     CUSTOM_RULESDIR_ENVVAR,
     DEFAULT_RULESDIR,
@@ -357,6 +358,11 @@ def merge_config(file_config: Dict[Any, Any], cli_config: Namespace) -> Namespac
     # merge options that can be set only via a file config
     for entry, value in file_config.items():
         setattr(cli_config, entry, value)
+
+    # append default kinds to the custom list
+    kinds = file_config.get('kinds', [])
+    kinds.extend(DEFAULT_KINDS)
+    setattr(cli_config, 'kinds', kinds)
 
     return cli_config
 

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -98,7 +98,9 @@ def kind_from_path(path: Path, base=False) -> str:
 
     if str(path) == '/dev/stdin':
         return "playbook"
-    raise RuntimeError("Unable to determine file type for %s" % pathex)
+
+    # Unknown file types report a empty string (evaluated as False)
+    return ""
 
 
 class Lintable:
@@ -200,7 +202,7 @@ class Lintable:
 def get_yaml_files(options: Namespace) -> Dict[str, Any]:
     """Find all yaml files."""
     # git is preferred as it also considers .gitignore
-    git_command = ['git', 'ls-files', '-z', '*.yaml', '*.yml']
+    git_command = ['git', 'ls-files', '-z']
     _logger.info("Discovering files to lint: %s", ' '.join(git_command))
 
     out = None

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -135,7 +135,7 @@ class Runner:
             files = [value for n, value in enumerate(files) if value not in files[:n]]
 
             for file in self.lintables:
-                if file in self.checked_files:
+                if file in self.checked_files or not file.kind:
                     continue
                 _logger.debug(
                     "Examining %s of type %s",

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from ansiblelint.runner import Runner
+from ansiblelint.testing import run_ansible_lint
 
 
 @pytest.fixture
@@ -54,3 +55,12 @@ def test_full_vault(default_rules_collection):
         'examples/playbooks/vars/not_decryptable.yml', rules=default_rules_collection
     ).run()
     assert len(result) == 0
+
+
+def test_custom_kinds():
+    """Check if user defined kinds are used."""
+    result = run_ansible_lint('-vv', '--offline', 'examples/other/')
+    assert result.returncode == 0
+    # .yaml-too is not a recognized extension and unless is manually defined
+    # in our .ansible-lint config, the test would not identify it as yaml file.
+    assert "Examining examples/other/some.yaml-too of type yaml" in result.stderr

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -227,7 +227,7 @@ def test_get_yaml_files_git_verbose(reset_env_var, message_prefix, monkeypatch, 
     expected_info = (
         "ansiblelint",
         logging.INFO,
-        'Discovering files to lint: git ls-files -z *.yaml *.yml',
+        'Discovering files to lint: git ls-files -z',
     )
 
     assert expected_info in caplog.record_tuples
@@ -312,7 +312,7 @@ def test_cli_auto_detect(capfd):
     out, err = capfd.readouterr()
 
     # Confirmation that it runs in auto-detect mode
-    assert "Discovering files to lint: git ls-files -z *.yaml *.yml" in err
+    assert "Discovering files to lint: git ls-files -z" in err
     # An expected rule match from our examples
     assert (
         "examples/playbooks/empty_playbook.yml:0: "


### PR DESCRIPTION
Instead of overriding all defaults when defining new mappings, the user defined ones are added at the top, so you do not have redefine all of them if you only want to tune one.

This also documents the feature, which was previously not documented.