### PR TITLE
Remove one false positive on pipe-fail rule

### DIFF
--- a/src/ansiblelint/rules/ShellWithoutPipefail.py
+++ b/src/ansiblelint/rules/ShellWithoutPipefail.py
@@ -20,7 +20,7 @@ class ShellWithoutPipefail(AnsibleLintRule):
     tags = ['command-shell']
     version_added = 'v4.1.0'
 
-    _pipefail_re = re.compile(r"^\s*set.*[+-][A-z]*o\s*pipefail")
+    _pipefail_re = re.compile(r"^\s*set.*[+-][A-z]*o\s*pipefail", re.M)
     _pipe_re = re.compile(r"(?<!\|)\|(?!\|)")
 
     def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
@@ -39,6 +39,6 @@ class ShellWithoutPipefail(AnsibleLintRule):
 
         return bool(
             self._pipe_re.search(unjinjad_cmd)
-            and not self._pipefail_re.match(unjinjad_cmd)
+            and not self._pipefail_re.search(unjinjad_cmd)
             and not convert_to_boolean(task['action'].get('ignore_errors', False))
         )

--- a/test/TestShellWithoutPipefail.py
+++ b/test/TestShellWithoutPipefail.py
@@ -48,6 +48,12 @@ SUCCESS_TASKS = '''
         set -eo pipefail
         false | cat
 
+    - name: pipeline with pipefail not at first line
+      shell: |
+        echo foo
+        set -eo pipefail
+        false | cat
+
     - name: pipeline without pipefail, ignoring errors
       shell: false | cat
       ignore_errors: true


### PR DESCRIPTION
Avoid triggering the rule if pipefail string is used anywhere inside the script instead of only the first line. We can assume user knew what to do if it used pipefail inside.

Fixes: #663