### PR TITLE
Clarify that verbosity can be incremented

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -228,7 +228,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         '-v',
         dest='verbosity',
         action='count',
-        help="Increase verbosity level",
+        help="Increase verbosity level (-vv for more)",
         default=0,
     )
     parser.add_argument(


### PR DESCRIPTION
Makes it clear that -v can be repeated in order to increase the verbosity of the tool.