### PR TITLE
Add .cache folder to default exclude list

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 # .ansible-lint
 exclude_paths:
+- .cache/  # implicit unless exclude_paths is defined in config
 - .github/
 # parseable: true
 # quiet: true

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -314,7 +314,7 @@ def merge_config(file_config: Dict[Any, Any], cli_config: Namespace) -> Namespac
     )
     # maps lists to their default config values
     lists_map = {
-        'exclude_paths': [],
+        'exclude_paths': [".cache"],
         'rulesdir': [],
         'skip_list': [],
         'tags': [],


### PR DESCRIPTION
To avoid false-positive results from users did not add .cache folder
to their .gitignore file, include it in the implicit exclude_paths.

Fixes: #1463