### PR TITLE
[RFC] src/ansiblelint/_prerun.py: Add extra link to current directory in cache

### DIFF
--- a/src/ansiblelint/_prerun.py
+++ b/src/ansiblelint/_prerun.py
@@ -193,15 +193,16 @@ def _install_galaxy_role() -> None:
         fqrn = role_name
     p = pathlib.Path(f"{options.project_dir}/.cache/roles")
     p.mkdir(parents=True, exist_ok=True)
-    link_path = p / f"{role_namespace}.{role_name}"
-    # despite documentation stating that is_file() reports true for symlinks,
-    # it appears that is_dir() reports true instead, so we rely on exits().
-    if not link_path.exists():
-        link_path.symlink_to(pathlib.Path("../..", target_is_directory=True))
-    _logger.info(
-        "Using %s symlink to current repository in order to enable Ansible to find the role using its expected full name.",
-        link_path,
-    )
+    for rolepath in [f"{role_namespace}.{role_name}", f"{role_name}"]:
+        link_path = p / rolepath
+        # despite documentation stating that is_file() reports true for symlinks,
+        # it appears that is_dir() reports true instead, so we rely on exits().
+        if not link_path.exists():
+            link_path.symlink_to(pathlib.Path("../..", target_is_directory=True))
+        _logger.info(
+            "Using %s symlink to current repository in order to enable Ansible to find the role using its expected full name.",
+            link_path,
+        )
 
 
 def _prepare_ansible_paths() -> None:


### PR DESCRIPTION

ansible-lint is now checking playbook with --syntax-check, so it needs
to have the current role in cache, otherwise it will fail with error like:

internal-error: the role 'foo' was not found ...

There has been a previous attempt to fix this by creating a link to
current role base directory and the link is named according to galaxy
information. This name has several issues:
- it's specific to galaxy. People not using galaxy doesn't really need
  to respect the galaxy usage. For instance, if they follow
  https://galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata
  they will put 'John Doe' in 'author' so the link will be useless
- it's uselessly breaking something which has been working before. The converge.yml
  molecule playbook is often containing only the role name (without any kind of
  namespace) and everything was fine. With the link name, people
  will have to edit every role having the issue and possibly their playbooks/
  requirements/... files too.

As a solution, this patch is also adding a link to the current role
directory name after the role name found in meta/main.yml or the
current directory name.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>