### PR TITLE
Make prerun module public

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -32,7 +32,6 @@ from typing import TYPE_CHECKING, List
 from enrich.console import should_do_markup
 
 from ansiblelint import cli
-from ansiblelint._prerun import check_ansible_presence, prepare_environment
 from ansiblelint.app import App
 from ansiblelint.color import (
     console,
@@ -44,6 +43,7 @@ from ansiblelint.color import (
 from ansiblelint.config import options
 from ansiblelint.constants import ANSIBLE_MISSING_RC, EXIT_CONTROL_C_RC
 from ansiblelint.file_utils import cwd
+from ansiblelint.prerun import check_ansible_presence, prepare_environment
 from ansiblelint.skip_utils import normalize_tag
 from ansiblelint.version import __version__
 

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -1,3 +1,4 @@
+"""Utilities for configuring ansible runtime environment."""
 import logging
 import os
 import pathlib

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from ansiblelint._prerun import prepare_environment
+from ansiblelint.prerun import prepare_environment
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3240


### PR DESCRIPTION
This change should allow molecule to reuse this module without having to perform private imports.