### PR TITLE
Fix install galaxy role warning message

### DIFF
--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -181,8 +181,8 @@ def _install_galaxy_role() -> None:
     Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
 
     As an alternative, you can add 'role-name' to either skip_list or warn_list.
-    """,
-                fqrn,
+    """
+                % fqrn
             )
             if 'role-name' in options.warn_list:
                 _logger.warning(msg)


### PR DESCRIPTION
Fix the msg value to use '%s' and remove extra ',' to get a
properly formatted message and the '%s' sequence replaced.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>