### PR TITLE
Enable prepare_environment to be used without cli

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -27,7 +27,7 @@ import pathlib
 import subprocess
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from enrich.console import should_do_markup
 
@@ -76,9 +76,9 @@ def initialize_logger(level: int = 0) -> None:
     _logger.debug("Logging initialized to level %s", logging_level)
 
 
-def initialize_options(arguments: List[str]):
+def initialize_options(arguments: Optional[List[str]] = None) -> None:
     """Load config options and store them inside options module."""
-    new_options = cli.get_config(arguments)
+    new_options = cli.get_config(arguments or [])
     new_options.cwd = pathlib.Path.cwd()
 
     if new_options.version:
@@ -104,6 +104,8 @@ def initialize_options(arguments: List[str]):
     options.tags = [normalize_tag(tag) for tag in options.tags]
     options.skip_list = [normalize_tag(tag) for tag in options.skip_list]
     options.warn_list = [normalize_tag(tag) for tag in options.warn_list]
+
+    options.configured = True
 
 
 def report_outcome(result: "LintResult", options, mark_as_success=False) -> int:

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -53,6 +53,7 @@ BASE_KINDS = [
 
 options = Namespace(
     colored=True,
+    configured=False,
     cwd=".",
     display_relative_path=True,
     exclude_paths=[],

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -96,6 +96,14 @@ def check_ansible_presence(exit_on_error: bool = False) -> Tuple[str, str]:
 
 def prepare_environment() -> None:
     """Make dependencies available if needed."""
+    if not options.configured:
+        # Allow method to be used without calling the command line, so we can
+        # reuse it in other tools, like molecule.
+        # pylint: disable=import-outside-toplevel,cyclic-import
+        from ansiblelint.__main__ import initialize_options
+
+        initialize_options()
+
     if not options.offline and os.path.exists("requirements.yml"):
 
         cmd = [


### PR DESCRIPTION
Allows reuse of prepare_environment() outside the ansible-lint, so
other tools like molecule can reuse its logic.