### PR TITLE
Fix MetaMainHasInfoRule when running from meta dir

### DIFF
--- a/src/ansiblelint/rules/MetaMainHasInfoRule.py
+++ b/src/ansiblelint/rules/MetaMainHasInfoRule.py
@@ -70,7 +70,7 @@ class MetaMainHasInfoRule(AnsibleLintRule):
 
         # since Ansible 2.10 we can add a meta/requirements.yml but
         # we only want to match on meta/main.yml
-        if not str(file.path).endswith('/main.yml'):
+        if file.path.name != 'main.yml':
             return []
 
         galaxy_info = data.get('galaxy_info', False)


### PR DESCRIPTION
When ansible-lint is run directly from the meta directory for meta/main.yml, file.path is simply 'main.yml' and fails the `str(file.path).endswith('/main.yml')` test.

This PR attempts to fix this by instead comparing the name attribute of the Path object to 'main.yml'.