### PR TITLE
Add ability to ignore jinja2 templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,10 @@ repos:
   rev: v1.26.0
   hooks:
   - id: yamllint
+    exclude: >
+      (?x)^(
+        examples/other/some.j2.yaml
+      )$
     files: \.(yaml|yml)$
     types: [file, yaml]
     entry: yamllint --strict

--- a/examples/other/some.j2.yaml
+++ b/examples/other/some.j2.yaml
@@ -1,0 +1,2 @@
+# Used to validate that a templated YAML file does not confuse the linter
+{% include 'port.j2' %}

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -13,6 +13,8 @@ from ansiblelint.constants import ANSIBLE_MISSING_RC
 
 DEFAULT_KINDS = [
     # Do not sort this list, order matters.
+    {"jinja2": "**/*.j2"},  # jinja2 templates are not always parsable as something else
+    {"jinja2": "**/*.j2.*"},
     {"requirements": "**/meta/requirements.yml"},  # v1 only
     # https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
     {"galaxy": "**/galaxy.yml"},  # Galaxy collection meta
@@ -40,6 +42,10 @@ BASE_KINDS = [
     # These assignations are only for internal use and are only inspired by
     # MIME/IANA model. Their purpose is to be able to process a file based on
     # it type, including generic processing of text files using the prefix.
+    {
+        "text/jinja2": "**/*.j2"
+    },  # jinja2 templates are not always parsable as something else
+    {"text/jinja2": "**/*.j2.*"},
     {"text/json": "**/*.json"},  # standardized
     {"text/markdown": "**/*.md"},  # https://tools.ietf.org/html/rfc7763
     {"text/rst": "**/*.rst"},  # https://en.wikipedia.org/wiki/ReStructuredText

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -89,7 +89,11 @@ class AnsibleLintRule(BaseRule):
     # https://github.com/ansible-community/ansible-lint/issues/744
     def matchtasks(self, file: Lintable) -> List[MatchError]:
         matches: List[MatchError] = []
-        if not self.matchtask or file.kind not in ['handlers', 'tasks', 'playbook']:
+        if (
+            not self.matchtask
+            or file.kind not in ['handlers', 'tasks', 'playbook']
+            or file.base_kind != 'text/yaml'
+        ):
             return matches
 
         yaml = ansiblelint.utils.parse_yaml_linenumbers(file)
@@ -136,7 +140,7 @@ class AnsibleLintRule(BaseRule):
 
     def matchyaml(self, file: Lintable) -> List[MatchError]:
         matches: List[MatchError] = []
-        if not self.matchplay:
+        if not self.matchplay or file.base_kind != 'text/yaml':
             return matches
 
         yaml = ansiblelint.utils.parse_yaml_linenumbers(file)

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -737,6 +737,7 @@ def parse_yaml_linenumbers(lintable: Lintable) -> AnsibleBaseYAMLObject:
         loader.construct_mapping = construct_mapping
         data = loader.get_single_data()
     except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
+        logging.exception(e)
         raise SystemExit("Failed to parse YAML in %s: %s" % (lintable.path, str(e)))
     return data
 

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -64,3 +64,4 @@ def test_custom_kinds():
     # .yaml-too is not a recognized extension and unless is manually defined
     # in our .ansible-lint config, the test would not identify it as yaml file.
     assert "Examining examples/other/some.yaml-too of type yaml" in result.stderr
+    assert "Examining examples/other/some.j2.yaml of type jinja2" in result.stderr

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -365,6 +365,10 @@ def test_is_playbook():
             "tasks",
         ),  # relative path involved
         ("galaxy.yml", "galaxy"),
+        ("foo.j2.yml", "jinja2"),
+        ("foo.yml.j2", "jinja2"),
+        ("foo.j2.yaml", "jinja2"),
+        ("foo.yaml.j2", "jinja2"),
     ),
 )
 def test_default_kinds(monkeypatch, path: str, kind: FileType) -> None:


### PR DESCRIPTION
Fixes issue where jinja2 templated YAML files would endup raising errors, as the YAML loader would have failed to load them.

Also enables printing of exception traceback when on debug level to make it possible to find similar logic bugs.