### PR TITLE
Add DebOps project to eco test pipeline

### DIFF
--- a/playbooks/eco.yml
+++ b/playbooks/eco.yml
@@ -23,6 +23,9 @@
       - name: ansible_collection_system
         url: https://github.com/devroles/ansible_collection_system
         contact: greg-hellings
+      - name: debops
+        url: https://github.com/debops/debops
+        contact: drybjed
   tasks:
 
     - name: Clone repo


### PR DESCRIPTION
The 'debops/debops' repository contains a set of Ansible roles and
playbooks focused on Debian and Ubuntu server management.