### PR TITLE
Use types for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
     name: Ansible-lint
     description: This hook runs ansible-lint.
     entry: ansible-lint --force-color
+    types: [yaml]
     language: python
     # do not pass files to ansible-lint, see:
     # https://github.com/ansible-community/ansible-lint/issues/611


### PR DESCRIPTION
updates to pre-commit have allowed you to specify types of files in the hook itself instead of having to have the user specify a files regex (documentation [here](https://pre-commit.com/index.html#filtering-files-with-types)).

By adding `types: [yaml]` your user does not need to put `files: \.(yaml|yml)$` , which makes using it much easier. This is a backwards compatible change as types: [yaml] and `files: \.(yaml|yml)$` will match all the same files.