### PR TITLE
New Rule - Variable Naming Standards

### DIFF
--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -1,0 +1,124 @@
+from typing import TYPE_CHECKING, List, Any, Dict, Union
+
+from ansiblelint.config import options
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.text import toidentifier
+from ansiblelint.utils import parse_yaml_from_file
+import ansible.parsing.yaml.objects
+
+# if TYPE_CHECKING:
+#     from typing import Any, Dict, Union
+#     from ansiblelint.constants import odict
+
+import re # used for regex string validation
+import json
+
+# ---------------------------------------------------------------
+# TODO: Check task for registered variables
+# TODO: Check task for set_facts
+# TODO: Check vars files
+# TODO: Ensure variable names do not match one of the magic variable names
+#       https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#special-variables
+# TODO: Provide comment on following open issue:
+#       [Ansible-lint does not catch invalid variable names](https://github.com/ansible/ansible-lint/issues/447)
+# ---------------------------------------------------------------
+
+# properties/parameters are prefixed and postfixed with `__`
+def is_property(k):
+    return (k.startswith('__') and k.endswith('__'))
+
+def is_invalid_variable_name(text):
+    patterns = '^[a-z0-9_]*$'
+    if re.search(patterns, text):
+      return False # string uses acceptable characters
+    else:
+      return True # string uses unacceptable characters
+
+class VariableNamingRule(AnsibleLintRule):
+    id = 'var-naming'
+    base_msg = 'All variables should be named using only lowercase and underscores'
+    shortdesc = base_msg
+    description = 'All variables should be named using only lowercase and underscores'
+    severity = 'MEDIUM' # ansible-lint displays severity when with --parseable-severity option
+    tags = ['formatting', 'readability']
+    version_added = 'v5.0.5'
+
+    def recursive_items(self, dictionary):
+        """Return a recursive search for all keys in the dictionary """
+
+        for key, value in dictionary.items():
+            # Avoid internal properties in the dictionary
+            if not is_property(key):
+                # Recurse if value is another ansible dictionary
+                if isinstance(value, ansible.parsing.yaml.objects.AnsibleMapping):
+                    yield (key, value)
+                    yield from self.recursive_items(value)
+                else:
+                    yield (key, value)
+
+    def matchplay(self, file: "Lintable", data: "odict[str, Any]") -> List["MatchError"]:
+        """Return matches found for a specific playbook."""
+        results = []
+
+        # If the Play uses the 'vars' section to set variables
+        vars = data.get('vars', {})
+        for key, value in self.recursive_items(vars):
+            if is_invalid_variable_name(key):
+                results.append(
+                    self.create_matcherror(
+                          filename=file, 
+                          linenumber=vars['__line__'], 
+                          message="Play defines variable '" + key + "' within 'vars' section that violates variable naming standards"
+                    )
+                )
+
+        return results
+
+    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+        """Return matches for task based variables."""
+
+        results: List["MatchError"] = []
+
+        # If the task uses the 'vars' section to set variables
+        vars = task.get('vars', {})
+        for key, value in self.recursive_items(vars):
+            if is_invalid_variable_name(key):
+                return "Task defines variables within 'vars' section that violates variable naming standards"
+
+        # If the task uses the 'set_fact' module
+        ansible_module = task['action']['__ansible_module__']
+        ansible_action = task['action']
+        if ansible_module == 'set_fact':
+            for key, value in self.recursive_items(ansible_action):
+                if is_invalid_variable_name(key):
+                    return "Task uses 'set_fact' to define variables that violates variable naming standards"
+
+        # If the task registers a variable
+        registered_var = task.get('register', None)
+        if registered_var and is_invalid_variable_name(registered_var):
+            return "Task registers a variable that violates variable naming standards"
+
+        return False
+
+    def matchyaml(self, file: Lintable) -> List["MatchError"]:
+        """Return matches for variables defined in vars files."""
+
+        results: List["MatchError"] = []
+        meta_data = {}
+
+        if file.kind == "vars":
+            meta_data = parse_yaml_from_file(str(file.path))
+            for key, value in self.recursive_items(meta_data):
+                if is_invalid_variable_name(key):
+                    results.append(
+                        self.create_matcherror(
+                              filename=file, 
+                              #linenumber=vars['__line__'], 
+                              message="File defines variable '" + key + "' that violates variable naming standards"
+                        )
+                    )
+        else:
+            results.extend(super().matchyaml(file))
+        return results

--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -8,22 +8,7 @@ from ansiblelint.text import toidentifier
 from ansiblelint.utils import parse_yaml_from_file
 import ansible.parsing.yaml.objects
 
-# if TYPE_CHECKING:
-#     from typing import Any, Dict, Union
-#     from ansiblelint.constants import odict
-
-import re # used for regex string validation
-import json
-
-# ---------------------------------------------------------------
-# TODO: Check task for registered variables
-# TODO: Check task for set_facts
-# TODO: Check vars files
-# TODO: Ensure variable names do not match one of the magic variable names
-#       https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#special-variables
-# TODO: Provide comment on following open issue:
-#       [Ansible-lint does not catch invalid variable names](https://github.com/ansible/ansible-lint/issues/447)
-# ---------------------------------------------------------------
+import re
 
 # properties/parameters are prefixed and postfixed with `__`
 def is_property(k):

--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -1,25 +1,26 @@
-from typing import TYPE_CHECKING, List, Any, Dict, Union
+from typing import List, Any, Dict, Union
 
-from ansiblelint.config import options
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.text import toidentifier
 from ansiblelint.utils import parse_yaml_from_file
 import ansible.parsing.yaml.objects
 
 import re
 
+
 # properties/parameters are prefixed and postfixed with `__`
 def is_property(k):
     return (k.startswith('__') and k.endswith('__'))
 
+
 def is_invalid_variable_name(text):
     patterns = '^[a-z0-9_]*$'
     if re.search(patterns, text):
-      return False # string uses acceptable characters
+        return False  # string uses acceptable characters
     else:
-      return True # string uses unacceptable characters
+        return True  # string uses unacceptable characters
+
 
 class VariableNamingRule(AnsibleLintRule):
     id = 'var-naming'
@@ -53,9 +54,9 @@ class VariableNamingRule(AnsibleLintRule):
             if is_invalid_variable_name(key):
                 results.append(
                     self.create_matcherror(
-                          filename=file, 
-                          linenumber=vars['__line__'], 
-                          message="Play defines variable '" + key + "' within 'vars' section that violates variable naming standards"
+                        filename=file, 
+                        linenumber=vars['__line__'], 
+                        message="Play defines variable '" + key + "' within 'vars' section that violates variable naming standards"
                     )
                 )
 
@@ -63,8 +64,6 @@ class VariableNamingRule(AnsibleLintRule):
 
     def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
         """Return matches for task based variables."""
-
-        results: List["MatchError"] = []
 
         # If the task uses the 'vars' section to set variables
         vars = task.get('vars', {})
@@ -99,9 +98,9 @@ class VariableNamingRule(AnsibleLintRule):
                 if is_invalid_variable_name(key):
                     results.append(
                         self.create_matcherror(
-                              filename=file, 
-                              #linenumber=vars['__line__'], 
-                              message="File defines variable '" + key + "' that violates variable naming standards"
+                            filename=file, 
+                            # linenumber=vars['__line__'], 
+                            message="File defines variable '" + key + "' that violates variable naming standards"
                         )
                     )
         else:

--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -1,5 +1,6 @@
-from typing import List, Any, Dict, Union
-
+from typing import TYPE_CHECKING, List, Any, Dict, Union
+if TYPE_CHECKING:
+    from ansiblelint.constants import odict
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
@@ -27,7 +28,7 @@ class VariableNamingRule(AnsibleLintRule):
     base_msg = 'All variables should be named using only lowercase and underscores'
     shortdesc = base_msg
     description = 'All variables should be named using only lowercase and underscores'
-    severity = 'MEDIUM' # ansible-lint displays severity when with --parseable-severity option
+    severity = 'MEDIUM'  # ansible-lint displays severity when with --parseable-severity option
     tags = ['formatting', 'readability']
     version_added = 'v5.0.5'
 
@@ -54,8 +55,8 @@ class VariableNamingRule(AnsibleLintRule):
             if is_invalid_variable_name(key):
                 results.append(
                     self.create_matcherror(
-                        filename=file, 
-                        linenumber=vars['__line__'], 
+                        filename=file,
+                        linenumber=vars['__line__'],
                         message="Play defines variable '" + key + "' within 'vars' section that violates variable naming standards"
                     )
                 )
@@ -98,8 +99,8 @@ class VariableNamingRule(AnsibleLintRule):
                 if is_invalid_variable_name(key):
                     results.append(
                         self.create_matcherror(
-                            filename=file, 
-                            # linenumber=vars['__line__'], 
+                            filename=file,
+                            # linenumber=vars['__line__'],
                             message="File defines variable '" + key + "' that violates variable naming standards"
                         )
                     )


### PR DESCRIPTION
Add new rule that checks for Variable Naming Standards in the following situations where variables can be declared.

- 'vars' section in the playbook
- 'vars' section in the task
- 'register:' section in the task
- set_fact tasks
- vars files (yaml)

Tested against some local content I had, below are the results of a test:

```
 $ ansible-lint
WARNING  Listing 24 violation(s) that are fatal
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'Another' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'Mother' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'TEST1' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'TEST2' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'That' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'ThatKey1' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:4: var-naming Play defines variable 'ThoseKeys' within 'vars' section that violates variable naming standards
my_namespace/my_collection/playbooks/play.yml:16: unnamed-task All tasks should be named
my_namespace/my_collection/playbooks/play.yml:16: var-naming Task registers a variable that violates variable naming standards
my_namespace/my_collection/roles/myrole/defaults/main.yml:0: var-naming File defines variable 'DefaultAnotherBadVarName' that violates variable naming standards
my_namespace/my_collection/roles/myrole/defaults/main.yml:0: var-naming File defines variable 'DefaultBadVariableName' that violates variable naming standards
my_namespace/my_collection/roles/myrole/handlers/main.yml:4: var-naming Task defines variables within 'vars' section that violates variable naming standards
my_namespace/my_collection/roles/myrole/handlers/main.yml:7: var-naming Play defines variable 'MyBadVariableName' within 'vars' section that violates variable naming standards
my_namespace/my_collection/roles/myrole/handlers/main.yml:10: var-naming Task uses 'set_fact' to define variables that violates variable naming standards
my_namespace/my_collection/roles/myrole/meta/main.yml:0: meta-no-info Role info should contain platforms
my_namespace/my_collection/roles/myrole/meta/main.yml:1: meta-incorrect Should change default metadata: author
my_namespace/my_collection/roles/myrole/meta/main.yml:1: meta-incorrect Should change default metadata: company
my_namespace/my_collection/roles/myrole/meta/main.yml:1: meta-incorrect Should change default metadata: license
my_namespace/my_collection/roles/myrole/tasks/main.yml:3: var-naming Task defines variables within 'vars' section that violates variable naming standards
my_namespace/my_collection/roles/myrole/tasks/main.yml:6: var-naming Play defines variable 'MyBadVariableName' within 'vars' section that violates variable naming standards
my_namespace/my_collection/roles/myrole/tasks/main.yml:9: var-naming Task uses 'set_fact' to define variables that violates variable naming standards
my_namespace/my_collection/roles/myrole/vars/main.yml:0: var-naming File defines variable 'That' that violates variable naming standards
my_namespace/my_collection/roles/myrole/vars/main.yml:0: var-naming File defines variable 'VarsVariableName' that violates variable naming standards
my_namespace/my_collection/roles/myrole/vars/main.yml:0: var-naming File defines variable 'hasMore2' that violates variable naming standards
You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - meta-incorrect  # meta/main.yml default values should be changed
  - meta-no-info  # meta/main.yml should contain relevant info
  - unnamed-task  # All tasks should be named
  - var-naming  # All variables should be named using only lowercase and underscores
Finished with 24 failure(s), 0 warning(s) on 10 files.
```
