### PR TITLE
Retry prepare environment three times before failing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,7 @@ repos:
     - flaky
     - pytest
     - ruamel.yaml
+    - tenacity
     - types-PyYAML
     - wcmatch
     - yamllint
@@ -111,5 +112,6 @@ repos:
     - pyyaml
     - rich
     - ruamel.yaml
+    - tenacity
     - sphinx
     - wcmatch

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -35,6 +35,7 @@ requests==2.25.1
 rich==10.1.0
 ruamel.yaml.clib==0.2.2
 ruamel.yaml==0.17.2 ; python_version >= "3.7"
+six==1.15.0
 snowballstemmer==2.1.0
 sphinx-ansible-theme==0.3.2
 sphinx-notfound-page==0.6
@@ -47,6 +48,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-programoutput2==2.0a1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+tenacity==7.0.0
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 wcmatch==8.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ install_requires =
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
   ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
   # NOTE: per issue #509 0.15.34 included in debian backports
+  tenacity
   typing-extensions; python_version < "3.8"
   wcmatch>=7.0  # MIT
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -27,6 +27,8 @@ pyyaml==5.4.1
 rich==10.1.0
 ruamel.yaml.clib==0.2.2
 ruamel.yaml==0.17.2 ; python_version >= "3.7"
+six==1.15.0
+tenacity==7.0.0
 toml==0.10.2
 typing-extensions==3.7.4.3
 wcmatch==8.1.2


### PR DESCRIPTION
This should avoid random error caused by galaxy servers returning errors.

This was observed at https://2b9c3acc2f2fe4180781-3849b03cfcb04d12316556dd4e593ed3.ssl.cf1.rackcdn.com/784197/1/gate/openstack-tox-linters/3c69524/job-output.txt