### PR TITLE
Ensure that the role file is not a file

### DIFF
--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -822,7 +822,7 @@ def _extend_with_roles(lintables: List[Lintable]) -> None:
             role = lintable.path
             while role.parent.name != "roles" and role.name:
                 role = role.parent
-            if role.exists:
+            if role.exists and not role.is_file():
                 lintable = Lintable(role, kind="role")
                 if lintable not in lintables:
                     _logger.debug("Added role: %s", lintable)


### PR DESCRIPTION
If a role contains something like a file called roles/.gitkeep,
ansible-lint will classify it as a role while it has no chance
to be a role (since it's a file). Add a check in _extend_with_roles()
to avoid linting files as a role.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>