### PR TITLE
Ignore files from inside templates/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
   - id: yamllint
     exclude: >
       (?x)^(
+        examples/playbooks/templates/.*|
         examples/other/some.j2.yaml
       )$
     files: \.(yaml|yml)$

--- a/examples/playbooks/templates/not-valid.yaml
+++ b/examples/playbooks/templates/not-valid.yaml
@@ -1,0 +1,2 @@
+# Used to validate that a templated YAML file does not confuse the linter
+{% include 'port.j2' %}

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -46,6 +46,7 @@ BASE_KINDS = [
         "text/jinja2": "**/*.j2"
     },  # jinja2 templates are not always parsable as something else
     {"text/jinja2": "**/*.j2.*"},
+    {"text": "**/templates/**/*.*"},  # templates are likely not validable
     {"text/json": "**/*.json"},  # standardized
     {"text/markdown": "**/*.md"},  # https://tools.ietf.org/html/rfc7763
     {"text/rst": "**/*.rst"},  # https://en.wikipedia.org/wiki/ReStructuredText


### PR DESCRIPTION
Avoid using file extensions from files under templates/ folders as they are unlikely to validate
using their extension type. For example .yaml files from these are likely jinja2 templated.

Fixes: #1511