### PR TITLE
Utilize yamllint severity levels for rule severity

### DIFF
--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -83,6 +83,11 @@ class YamllintRule(AnsibleLintRule):
             for p in run_yamllint(
                 file.content, YamllintRule.config, filepath=file.path
             ):
+                self.severity = 'VERY_LOW'
+                if p.level == "error":
+                    self.severity = 'MEDIUM'
+                if p.desc.endswith("(syntax)"):
+                    self.severity = 'VERY_HIGH'
                 matches.append(
                     self.create_matcherror(
                         message=p.desc,


### PR DESCRIPTION
yamllint allows to categorize found problems as "error" or "warning"  
ansible-lint treats them all as having `VERY_LOW` severity anyway

I think that the rule categorization of yamllint shouldn't be lost, after all it can be configured with a `.yamllint` config file to fit the user's needs.

This PR keeps the `VERY_LOW` severity categorization for problems that yamllint reports as "warning" just as before, but uses `MEDIUM` severity for problems reported as "error".  
Syntax errors reported by yamllint are raised to `VERY_HIGH` severity, though they won't be used as long as ansible-lint skips further rule checking after its own syntax check.