### PR TITLE
change: add file: Lintable argument to <rule_class>.match{,task} methods

### DIFF
--- a/examples/rules/TaskHasTag.py
+++ b/examples/rules/TaskHasTag.py
@@ -1,7 +1,12 @@
 """Example implementation of a rule requiring tasks to have tags set."""
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class TaskHasTag(AnsibleLintRule):
@@ -12,7 +17,9 @@ class TaskHasTag(AnsibleLintRule):
     description = 'Tasks must have tag'
     tags = ['productivity', 'tags']
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         """Task matching method."""
         if isinstance(task, str):
             return False

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -2,6 +2,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 if TYPE_CHECKING:
+    from typing import Optional
+
     from ansiblelint.constants import odict
     from ansiblelint.errors import MatchError
     from ansiblelint.file_utils import Lintable
@@ -43,7 +45,9 @@ class BaseRule:
         """Return matches found for a specific line."""
         return []
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: "Optional[Lintable]" = None
+    ) -> Union[bool, str]:
         """Confirm if current rule is matching a specific task."""
         return False
 

--- a/src/ansiblelint/rules/CommandHasChangesCheckRule.py
+++ b/src/ansiblelint/rules/CommandHasChangesCheckRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class CommandHasChangesCheckRule(AnsibleLintRule):
@@ -38,7 +43,9 @@ class CommandHasChangesCheckRule(AnsibleLintRule):
 
     _commands = ['command', 'shell', 'raw']
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         if task["__ansible_action_type__"] == 'task':
             if task["action"]["__ansible_module__"] in self._commands:
                 return (

--- a/src/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
+++ b/src/ansiblelint/rules/CommandsInsteadOfArgumentsRule.py
@@ -19,10 +19,15 @@
 # THE SOFTWARE.
 
 import os
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import convert_to_boolean, get_first_cmd_arg
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
@@ -47,7 +52,9 @@ class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
         'rm': 'state=absent',
     }
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         if task["action"]["__ansible_module__"] in self._commands:
             first_cmd_arg = get_first_cmd_arg(task)
             if not first_cmd_arg:

--- a/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -19,10 +19,15 @@
 # THE SOFTWARE.
 
 import os
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import convert_to_boolean, get_first_cmd_arg
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class CommandsInsteadOfModulesRule(AnsibleLintRule):
@@ -59,7 +64,9 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         'yum': 'yum',
     }
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         if task['action']['__ansible_module__'] not in self._commands:
             return False
 

--- a/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -3,10 +3,15 @@
 
 import re
 import sys
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import nested_items
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class ComparisonToEmptyStringRule(AnsibleLintRule):
@@ -22,7 +27,9 @@ class ComparisonToEmptyStringRule(AnsibleLintRule):
 
     empty_string_compare = re.compile("[=!]= ?(\"{2}|'{2})")
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         for k, v, _ in nested_items(task):
             if k == 'when':
                 if isinstance(v, str):

--- a/src/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/src/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -2,10 +2,15 @@
 # Copyright (c) 2018-2021, Ansible Project
 
 import re
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import nested_items
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class ComparisonToLiteralBoolRule(AnsibleLintRule):
@@ -21,7 +26,9 @@ class ComparisonToLiteralBoolRule(AnsibleLintRule):
 
     literal_bool_compare = re.compile("[=!]= ?(True|true|False|false)")
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         for k, v, _ in nested_items(task):
             if k == 'when':
                 if isinstance(v, str):

--- a/src/ansiblelint/rules/DeprecatedModuleRule.py
+++ b/src/ansiblelint/rules/DeprecatedModuleRule.py
@@ -1,8 +1,13 @@
 # Copyright (c) 2018, Ansible Project
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class DeprecatedModuleRule(AnsibleLintRule):
@@ -60,7 +65,9 @@ class DeprecatedModuleRule(AnsibleLintRule):
         'include',
     ]
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         module = task["action"]["__ansible_module__"]
         if module in self._modules:
             message = '{0} {1}'

--- a/src/ansiblelint/rules/EnvVarsInCommandRule.py
+++ b/src/ansiblelint/rules/EnvVarsInCommandRule.py
@@ -18,10 +18,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import FILENAME_KEY, LINE_NUMBER_KEY, get_first_cmd_arg
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class EnvVarsInCommandRule(AnsibleLintRule):
@@ -51,7 +56,9 @@ class EnvVarsInCommandRule(AnsibleLintRule):
         FILENAME_KEY,
     ]
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         if task["action"]["__ansible_module__"] in ['command']:
             first_cmd_arg = get_first_cmd_arg(task)
             if not first_cmd_arg:

--- a/src/ansiblelint/rules/GitHasVersionRule.py
+++ b/src/ansiblelint/rules/GitHasVersionRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class GitHasVersionRule(AnsibleLintRule):
@@ -34,7 +39,9 @@ class GitHasVersionRule(AnsibleLintRule):
     tags = ['idempotency']
     version_added = 'historic'
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         return bool(
             task['action']['__ansible_module__'] == 'git'
             and task['action'].get('version', 'HEAD') == 'HEAD'

--- a/src/ansiblelint/rules/MercurialHasRevisionRule.py
+++ b/src/ansiblelint/rules/MercurialHasRevisionRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class MercurialHasRevisionRule(AnsibleLintRule):
@@ -34,7 +39,9 @@ class MercurialHasRevisionRule(AnsibleLintRule):
     tags = ['idempotency']
     version_added = 'historic'
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         return bool(
             task['action']['__ansible_module__'] == 'hg'
             and task['action'].get('revision', 'default') == 'default'

--- a/src/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/src/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -17,9 +17,15 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
+
 
 # Despite documentation mentioning 'preserve' only these modules support it:
 _modules_with_preserve = (
@@ -60,7 +66,9 @@ class MissingFilePermissionsRule(AnsibleLintRule):
         'lineinfile': False,
     }
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         module = task["action"]["__ansible_module__"]
         mode = task['action'].get('mode', None)
 

--- a/src/ansiblelint/rules/NestedJinjaRule.py
+++ b/src/ansiblelint/rules/NestedJinjaRule.py
@@ -22,9 +22,14 @@
 # THE SOFTWARE.
 
 import re
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class NestedJinjaRule(AnsibleLintRule):
@@ -42,8 +47,9 @@ class NestedJinjaRule(AnsibleLintRule):
 
     pattern = re.compile(r"{{(?:[^{}]*)?[^'\"]{{")
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
-
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         command = "".join(
             str(value)
             # task properties are stored in the 'action' key

--- a/src/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/src/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 from ansiblelint.rules import AnsibleLintRule
 
 if TYPE_CHECKING:
+    from typing import Optional
+
     from ansiblelint.constants import odict
     from ansiblelint.errors import MatchError
     from ansiblelint.file_utils import Lintable
@@ -31,7 +33,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
             if 'roles' not in data or data['roles'] is None:
                 return errors
             for role in data['roles']:
-                if self.matchtask(role):
+                if self.matchtask(role, file=file):
                     errors.append(self.create_matcherror(details=str({'when': role})))
         if isinstance(data, list):
             for play_item in data:
@@ -40,5 +42,7 @@ class NoFormattingInWhenRule(AnsibleLintRule):
                     errors = errors + sub_errors
         return errors
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         return 'when' in task and not self._is_valid(task['when'])

--- a/src/ansiblelint/rules/NoTabsRule.py
+++ b/src/ansiblelint/rules/NoTabsRule.py
@@ -1,10 +1,15 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 import sys
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import nested_items
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class NoTabsRule(AnsibleLintRule):
@@ -21,7 +26,9 @@ class NoTabsRule(AnsibleLintRule):
         ("lineinfile", "line"),
     ]
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         for k, v, parent in nested_items(task):
             if isinstance(k, str) and '\t' in k:
                 return True

--- a/src/ansiblelint/rules/OctalPermissionsRule.py
+++ b/src/ansiblelint/rules/OctalPermissionsRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class OctalPermissionsRule(AnsibleLintRule):
@@ -80,7 +85,9 @@ class OctalPermissionsRule(AnsibleLintRule):
             or group_more_generous_than_user
         )
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         if task["action"]["__ansible_module__"] in self._modules:
             mode = task['action'].get('mode', None)
 

--- a/src/ansiblelint/rules/PackageIsNotLatestRule.py
+++ b/src/ansiblelint/rules/PackageIsNotLatestRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class PackageIsNotLatestRule(AnsibleLintRule):
@@ -62,7 +67,9 @@ class PackageIsNotLatestRule(AnsibleLintRule):
         'zypper',
     ]
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         return (
             task['action']['__ansible_module__'] in self._package_managers
             and not task['action'].get('version')

--- a/src/ansiblelint/rules/RoleRelativePath.py
+++ b/src/ansiblelint/rules/RoleRelativePath.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class RoleRelativePath(AnsibleLintRule):
@@ -23,7 +28,9 @@ class RoleRelativePath(AnsibleLintRule):
         'win_template': 'win_templates',
     }
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         module = task['action']['__ansible_module__']
         if module not in self._module_to_path_folder:
             return False

--- a/src/ansiblelint/rules/ShellWithoutPipefail.py
+++ b/src/ansiblelint/rules/ShellWithoutPipefail.py
@@ -1,8 +1,13 @@
 import re
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import convert_to_boolean
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class ShellWithoutPipefail(AnsibleLintRule):
@@ -23,7 +28,9 @@ class ShellWithoutPipefail(AnsibleLintRule):
     _pipefail_re = re.compile(r"^\s*set.*[+-][A-z]*o\s*pipefail", re.M)
     _pipe_re = re.compile(r"(?<!\|)\|(?!\|)")
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         if task["__ansible_action_type__"] != "task":
             return False
 

--- a/src/ansiblelint/rules/TaskHasNameRule.py
+++ b/src/ansiblelint/rules/TaskHasNameRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class TaskHasNameRule(AnsibleLintRule):
@@ -34,5 +39,7 @@ class TaskHasNameRule(AnsibleLintRule):
     tags = ['idiom']
     version_added = 'historic'
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         return not task.get('name')

--- a/src/ansiblelint/rules/TaskNoLocalAction.py
+++ b/src/ansiblelint/rules/TaskNoLocalAction.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
-
 from ansiblelint.rules import AnsibleLintRule
 
 

--- a/src/ansiblelint/rules/UseCommandInsteadOfShellRule.py
+++ b/src/ansiblelint/rules/UseCommandInsteadOfShellRule.py
@@ -18,9 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class UseCommandInsteadOfShellRule(AnsibleLintRule):
@@ -35,7 +40,9 @@ class UseCommandInsteadOfShellRule(AnsibleLintRule):
     tags = ['command-shell', 'idiom']
     version_added = 'historic'
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         # Use unjinja so that we don't match on jinja filters
         # rather than pipes
         if task["action"]["__ansible_module__"] == 'shell':

--- a/src/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
+++ b/src/ansiblelint/rules/UseHandlerRatherThanWhenChangedRule.py
@@ -19,8 +19,9 @@
 # THE SOFTWARE.
 
 import sys
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
+from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
 
 
@@ -52,7 +53,9 @@ class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
     tags = ['idiom']
     version_added = 'historic'
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
+    ) -> Union[bool, str]:
         if task["__ansible_action_type__"] != 'task':
             return False
 
@@ -68,7 +71,6 @@ class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
 
 if 'pytest' in sys.modules:
 
-    from ansiblelint.file_utils import Lintable
     from ansiblelint.rules import RulesCollection
     from ansiblelint.runner import Runner
 

--- a/src/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
+++ b/src/ansiblelint/rules/UsingBareVariablesIsDeprecatedRule.py
@@ -20,9 +20,14 @@
 
 import os
 import re
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
 
 
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
@@ -40,7 +45,9 @@ class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
     _jinja = re.compile(r"{{.*}}", re.DOTALL)
     _glob = re.compile('[][*?]')
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
         loop_type = next((key for key in task if key.startswith("with_")), None)
         if loop_type:
             if loop_type in [

--- a/src/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/src/ansiblelint/rules/VariableHasSpacesRule.py
@@ -3,8 +3,9 @@
 
 import re
 import sys
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
+from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.utils import nested_items
 
@@ -21,7 +22,9 @@ class VariableHasSpacesRule(AnsibleLintRule):
     bracket_regex = re.compile(r"{{[^{\n' -]|[^ '\n}-]}}", re.MULTILINE | re.DOTALL)
     exclude_json_re = re.compile(r"[^{]{'\w+': ?[^{]{.*?}}")
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(
+        self, task: Dict[str, Any], file: Optional[Lintable] = None
+    ) -> Union[bool, str]:
         for k, v, _ in nested_items(task):
             if isinstance(v, str):
                 cleaned = self.exclude_json_re.sub("", v)
@@ -32,7 +35,6 @@ class VariableHasSpacesRule(AnsibleLintRule):
 
 if 'pytest' in sys.modules:
 
-    from ansiblelint.file_utils import Lintable
     from ansiblelint.rules import RulesCollection
     from ansiblelint.runner import Runner
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -114,7 +114,7 @@ class AnsibleLintRule(BaseRule):
 
             if 'action' not in task:
                 continue
-            result = self.matchtask(task)
+            result = self.matchtask(task, file=file)
             if not result:
                 continue
 


### PR DESCRIPTION
Add file: Lintable argument to match and matchtask methods of the rule
classes because there are cases that it is necessary to do some analyses
depends on the context, that is, file: Lintable, such like the followings.

- want to restrict tasks in 'main.yml' use include_tasks only
- want to restrict the level of inclusions with include_tasks to 2
- restrict keywords can be used depends on file path or name
- inhibit some keywords are used in the line depends on file name

Signed-Off-By: Satoru SATOH <satoru.satoh@gmail.com>