### PR TITLE
Add a py.typed file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,5 +107,8 @@ yamllint =
 [options.packages.find]
 where = src
 
+[options.package_data]
+ansiblelint = py.typed
+
 [codespell]
 skip = .tox,.mypy_cache,build,.git,.eggs,pip-wheel-metadata


### PR DESCRIPTION
Add a py.typed to the root directory of the package to allow mypy to use type hints when importing ansiblelint.