### PR TITLE
feat: Handle missing yamllint as rule violation

### DIFF
--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -97,6 +97,15 @@ class YamllintRule(AnsibleLintRule):
                         tag=p.rule,
                     )
                 )
+        else:
+            matches.append(
+                self.create_matcherror(
+                    message="yamllint.config module is not present",
+                    details="Install yamllint package so ansiblelint can invoke it.",
+                    filename="YamllintRule.py",
+                    linenumber=15,
+                )
+            )
 
         if matches:
             lines = file.content.splitlines()


### PR DESCRIPTION
*ansible-lint* ignores the fact *yamllint* is not installed. This way, important yaml linting might be missed, because the output does not inform the user, that *yamllint* is not present.
I made the change so when *yamllint* is not detected, the *ansible-lint* will handle it as rule violation so that it can be disabled using `.ansible-lint` configuration file if necessary.

`filename` and `linenumber` are filled arbitrary so it points the code with the text:
```
# yamllint is a soft-dependency (not installed by default)
```