### PR TITLE
Add new rule that detects use of blind ignore_errors: true

### DIFF
--- a/src/ansiblelint/rules/IgnoreErrorsRule.py
+++ b/src/ansiblelint/rules/IgnoreErrorsRule.py
@@ -14,7 +14,7 @@ class IgnoreErrorsRule(AnsibleLintRule):
     """Describe and test the IgnoreErrorsRule."""
 
     id = "ignore-errors"
-    shortdesc = 'Use failed_when and specify error codes instead of ignore_errors'
+    shortdesc = 'Use failed_when and specify error conditions instead of using ignore_errors'
     description = (
         'Instead of ignoring all errors, use ``failed_when:`` '
         'and specify acceptable error codes '

--- a/src/ansiblelint/rules/IgnoreErrorsRule.py
+++ b/src/ansiblelint/rules/IgnoreErrorsRule.py
@@ -1,0 +1,92 @@
+"""IgnoreErrorsRule used with ansible-lint."""
+import sys
+from typing import TYPE_CHECKING, Any, Dict, Union
+
+from ansiblelint.rules import AnsibleLintRule
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from ansiblelint.file_utils import Lintable
+
+
+class IgnoreErrorsRule(AnsibleLintRule):
+    """Describe and test the IgnoreErrorsRule."""
+
+    id = "ignore-errors"
+    shortdesc = 'Use failed_when and specify error codes instead of ignore_errors'
+    description = (
+        'Instead of ignoring all errors, use ``failed_when:`` '
+        'and specify acceptable error codes '
+        'to reduce the risk of ignoring important failures'
+    )
+    severity = 'LOW'
+    tags = ['unpredictability', 'experimental']
+    version_added = 'v5.0.7'
+
+    def matchtask(
+        self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
+    ) -> Union[bool, str]:
+
+        if task.get("ignore_errors"):
+            return True
+
+        return False
+
+
+if "pytest" in sys.modules:
+    import pytest
+
+    IGNORE_ERRORS_TRUE = '''
+- hosts: all
+  tasks:
+    - name: run apt-get update
+      command: apt-get update
+      ignore_errors: true
+'''
+
+    IGNORE_ERRORS_FALSE = '''
+- hosts: all
+  tasks:
+    - name: run apt-get update
+      command: apt-get update
+      ignore_errors: false
+'''
+
+    FAILED_WHEN = '''
+- hosts: all
+  tasks:
+    - name: disable apport
+      become: 'yes'
+      lineinfile:
+        line: "enabled=0"
+        dest: /etc/default/apport
+        mode: 0644
+        state: present
+      register: default_apport
+      failed_when: default_apport.rc !=0 and not default_apport.rc == 257
+'''
+
+    @pytest.mark.parametrize(
+        'rule_runner', (IgnoreErrorsRule,), indirect=['rule_runner']
+    )
+    def test_ignore_errors_true(rule_runner: Any) -> None:
+        """The task uses ignore_errors."""
+        results = rule_runner.run_playbook(IGNORE_ERRORS_TRUE)
+        assert len(results) == 1
+
+    @pytest.mark.parametrize(
+        'rule_runner', (IgnoreErrorsRule,), indirect=['rule_runner']
+    )
+    def test_ignore_errors_false(rule_runner: Any) -> None:
+        """The task uses ignore_errors: false, oddly enough."""
+        results = rule_runner.run_playbook(IGNORE_ERRORS_FALSE)
+        assert len(results) == 0
+
+    @pytest.mark.parametrize(
+        'rule_runner', (IgnoreErrorsRule,), indirect=['rule_runner']
+    )
+    def test_failed_when(rule_runner: Any) -> None:
+        """Instead of ignore_errors, this task uses failed_when."""
+        results = rule_runner.run_playbook(FAILED_WHEN)
+        assert len(results) == 0

--- a/test/TestRulesCollection.py
+++ b/test/TestRulesCollection.py
@@ -128,4 +128,4 @@ def test_rules_id_format() -> None:
         assert rule_id_re.match(
             rule.id
         ), f"R rule id {rule.id} did not match our required format."
-    assert len(rules) == 38
+    assert len(rules) == 39

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,14 @@ description =
   devel: ansible devel branch
   ansible29: ansible 2.9
   core: ansible-base 2.10
+  py: ansible-core 2.11
 extras =
   yamllint
   core: core
   ; devel: devel
 deps =
   ansible29: ansible>=2.9,<2.10
+  py: ansible-core>=2.11
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
   -r test-requirements.in
   -c test-requirements.txt


### PR DESCRIPTION
This PR adds a new rule name `ignore-errors` that will trigger if `ignore_errors: true` is used.

The reasoning behind this is that instead of ignoring all errors, the use of `failed_when:` and specified acceptable error codes to reduce the risk of ignoring important failures is recommended.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>