### PR TITLE
Improve file detection outside git repositories

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -314,7 +314,7 @@ def merge_config(file_config: Dict[Any, Any], cli_config: Namespace) -> Namespac
     )
     # maps lists to their default config values
     lists_map = {
-        'exclude_paths': [".cache"],
+        'exclude_paths': [".cache", ".git", ".hg", ".svn", ".tox"],
         'rulesdir': [],
         'skip_list': [],
         'tags': [],


### PR DESCRIPTION
Address bug related to detection of lintable files when run outside
a git repository.

- extend list of exclusions with few common directiories
- allow linter to identify any file type, not only those with
  yaml/yml extension (matches behavior of git ls-files variant)
- improve logging messages

Closes: #1549