### PR TITLE
Add metadata tag to the role-name rule

### DIFF
--- a/src/ansiblelint/rules/RoleNames.py
+++ b/src/ansiblelint/rules/RoleNames.py
@@ -49,7 +49,7 @@ class RoleNames(AnsibleLintRule):
     )
     severity = 'HIGH'
     done: List[str] = []  # already noticed roles list
-    tags = ['deprecations']
+    tags = ['deprecations', 'metadata']
     version_added = 'v4.3.0'
 
     def __init__(self) -> None:


### PR DESCRIPTION
role-name rule is based on the metadata info. Thus, it would be expected
by users to also exclude this task, when `-x metadata` is set in the
config

Signed-Off-By: Dmitriy Rabotyagov <noonedeadpunk@ya.ru>