### PR TITLE
Switch cache to user cache folder

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -59,6 +59,7 @@ BASE_KINDS = [
 
 
 options = Namespace(
+    cache_dir=".cache",
     colored=True,
     configured=False,
     cwd=".",


### PR DESCRIPTION
- instead of in-repo .cache folder make use of ~/.cache
- use a hash based on project_dir path to avoid cross-contamination between various projects
- avoids https://github.com/pypa/pip/issues/10005 which can get pip install to get stuck

Fixes: #1566 #1504