### PR TITLE
Disable comments-indentation yamllint rule

### DIFF
--- a/src/ansiblelint/rules/YamllintRule.py
+++ b/src/ansiblelint/rules/YamllintRule.py
@@ -28,6 +28,8 @@ except ImportError:
 YAMLLINT_CONFIG = """
 extends: default
 rules:
+  # https://github.com/adrienverge/yamllint/issues/384
+  comments-indentation: false
   document-start: disable
   # 160 chars was the default used by old E204 rule, but
   # you can easily change it or disable in your .yamllint file.


### PR DESCRIPTION
In order to avoid false positive results about comment identation,

Keep in mind that these settings are used only if there is no
.yamllint config inside the current repository. Users still have
the option to override the default value and reactivate the rule
if they want.

Related: https://github.com/adrienverge/yamllint/issues/384