### PR TITLE
Fix parseable severity

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -71,10 +71,10 @@ def choose_formatter_factory(
     r: Type[formatters.BaseFormatter[Any]] = formatters.Formatter
     if options_list.format == 'quiet':
         r = formatters.QuietFormatter
-    elif options_list.parseable or options_list.format == 'pep8':
-        r = formatters.ParseableFormatter
     elif options_list.parseable_severity:
         r = formatters.ParseableSeverityFormatter
+    elif options_list.parseable or options_list.format == 'pep8':
+        r = formatters.ParseableFormatter
     elif options_list.format == 'codeclimate':
         r = formatters.CodeclimateJSONFormatter
     return r


### PR DESCRIPTION
Address bug where passing `-p` or `-f pep8` would have prevented use of `--parseable-severity` option. This affected vscode-ansible which was passing both, thus failing to find severity in the output.