### PR TITLE
Add apt_key module to deprecated list

### DIFF
--- a/src/ansiblelint/rules/DeprecatedModuleRule.py
+++ b/src/ansiblelint/rules/DeprecatedModuleRule.py
@@ -63,6 +63,7 @@ class DeprecatedModuleRule(AnsibleLintRule):
         'vsphere_guest',
         'win_msi',
         'include',
+        'apt_key',
     ]
 
     def matchtask(


### PR DESCRIPTION
apt_key is deprecated.

See:
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html#notes
https://github.com/ansible/ansible/issues/55590