### PR TITLE
Make no-log-password rule an opt-in

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -38,7 +38,9 @@ skip_list:
 # Any rule that has the 'opt-in' tag will not be loaded unless its 'id' is
 # mentioned in the enable_list:
 enable_list:
-  - no-same-owner
+  - fqcn-builtins  # opt-in
+  - no-log-password  # opt-in
+  - no-same-owner  # opt-in
   # add yaml here if you want to avoid ignoring yaml checks when yamllint
   # library is missing. Normally its absence just skips using that rule.
   - yaml

--- a/src/ansiblelint/rules/NoLogPasswordsRule.py
+++ b/src/ansiblelint/rules/NoLogPasswordsRule.py
@@ -36,7 +36,7 @@ class NoLogPasswordsRule(AnsibleLintRule):
         "to a non False value to avoid accidental leaking of secrets."
     )
     severity = 'LOW'
-    tags = ["security", "experimental"]
+    tags = ["opt-in", "security", "experimental"]
     version_added = "v5.0.9"
 
     def matchtask(

--- a/test/TestRulesCollection.py
+++ b/test/TestRulesCollection.py
@@ -136,12 +136,12 @@ def test_rich_rule_listing() -> None:
 def test_rules_id_format() -> None:
     """Assure all our rules have consistent format."""
     rule_id_re = re.compile("^[a-z-]{4,30}$")
-    options.enable_list = ['no-same-owner']
+    options.enable_list = ['no-same-owner', 'no-log-password', 'no-same-owner']
     rules = RulesCollection(
         [os.path.abspath('./src/ansiblelint/rules')], options=options
     )
     for rule in rules:
         assert rule_id_re.match(
             rule.id
-        ), f"R rule id {rule.id} did not match our required format."
+        ), f"Rule id {rule.id} did not match our required format."
     assert len(rules) == 40


### PR DESCRIPTION
Moves no-log-password from being experimental to also be an opt-in.

This means it will not be run at all unless user is enabling it
in the config.

Related: https://github.com/ansible-community/ansible-lint/discussions/1605
Closing: #1591