### PR TITLE
Make ansible-lint recognize inventory.yml files

### DIFF
--- a/examples/inventory.yml
+++ b/examples/inventory.yml
@@ -1,0 +1,30 @@
+# https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
+ungrouped: {}
+all:
+  hosts:
+    mail.example.com:
+  children:
+    webservers:
+      hosts:
+        foo.example.com:
+        bar.example.com:
+    dbservers:
+      hosts:
+        one.example.com:
+        two.example.com:
+        three.example.com:
+    east:
+      hosts:
+        foo.example.com:
+        one.example.com:
+        two.example.com:
+    west:
+      hosts:
+        bar.example.com:
+        three.example.com:
+    prod:
+      children:
+        east: {}
+    test:
+      children:
+        west: {}

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -15,6 +15,7 @@ DEFAULT_KINDS = [
     # Do not sort this list, order matters.
     {"jinja2": "**/*.j2"},  # jinja2 templates are not always parsable as something else
     {"jinja2": "**/*.j2.*"},
+    {"inventory": "**/inventory.yml"},
     {"requirements": "**/meta/requirements.yml"},  # v1 only
     # https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
     {"galaxy": "**/galaxy.yml"},  # Galaxy collection meta


### PR DESCRIPTION
This fixes a bug that was originally reported on vscode-ansible, where it was observed that inventory files reported problems. From now on we do assume `inventory.yml` named files are inventory files.

Fixes: https://github.com/ansible-community/vscode-ansible/issues/126