### PR TITLE
Improve install_collection implementation

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -60,7 +60,7 @@ BASE_KINDS = [
 
 
 options = Namespace(
-    cache_dir=".cache",
+    cache_dir=None,
     colored=True,
     configured=False,
     cwd=".",


### PR DESCRIPTION
- assure at default verbosity we do log ansible-galaxy command ran (info level is not logged by default)
- add ability to specify destination for install_collection
- assure we inject our own cache to top of collection path when present
- allow use of require_collection without a cache folder.

Note: this is likely the last change made to prerun code before moving this code into newly created standalone library https://github.com/ansible-community/ansible-compat/issues/4