### PR TITLE
Remove unused intersphinx mappings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -292,13 +292,6 @@ latex_documents = [
 
 autoclass_content = 'both'
 
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/2/', (None, '../python2-2.7.13.inv')),
-    'python3': ('https://docs.python.org/3/', (None, '../python3-3.6.2.inv')),
-    'jinja2': ('http://jinja.pocoo.org/docs/', (None, '../jinja2-2.9.7.inv')),
-}
-
-
 # table width fix via: https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
 html_static_path = ['_static']
 


### PR DESCRIPTION
This sorts an issue we found this morning where building docs failed due cloudfare flakiness. I suspect these went in as part of some copy/paste routine from another project.