### PR TITLE
Improve pre-commit output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
   # --no-annotate is used in order to prevent conflicts with PRs produced by dependency-bot
   pip-compile --no-annotate --output-file=test-requirements.txt setup.py test-requirements.in
   pip-compile --no-annotate --output-file=docs/requirements.txt setup.py docs/requirements.in
-  {envpython} -m pre_commit run {posargs:--all-files --hook-stage manual -v}
+  {envpython} -m pre_commit run {posargs:--all-files --show-diff-on-failure --hook-stage manual}
 passenv =
   {[testenv]passenv}
   PRE_COMMIT_HOME


### PR DESCRIPTION
* avoid running pre-commit in verbose by default
* use `--show-diff-on-failure` to allow identification of the problem