### PR TITLE
Run pip-compile as a hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,32 @@ repos:
     language: system
     files: >-
       ^setup\.py$
+  - id: pip-compile
+    name: pip-compile
+    entry: pip-compile -q --no-annotate --output-file=test-requirements.txt setup.py test-requirements.in
+    language: system
+    files: ^(test-requirements\.(txt|in)|)$
+    pass_filenames: false
+  - id: pip-compile-docs
+    name: pip-compile-docs
+    entry: pip-compile -q --no-annotate --output-file=docs/requirements.txt docs/requirements.in setup.py
+    language: system
+    files: ^(docs\/requirements\.(txt|in)|)$
+    pass_filenames: false
+  - id: pip-compile-upgrade
+    name: pip-compile-upgrade
+    entry: pip-compile -q --upgrade --no-annotate --output-file=test-requirements.txt setup.py test-requirements.in
+    language: system
+    files: ^(test-requirements\.(txt|in)|)$
+    pass_filenames: false
+    stages: [manual]
+  - id: pip-compile-docs-upgrade
+    name: pip-compile-docs-upgrade
+    entry: pip-compile -q --upgrade --no-annotate --output-file=docs/requirements.txt docs/requirements.in setup.py
+    language: system
+    files: ^(docs\/requirements\.(txt|in)|)$
+    pass_filenames: false
+    stages: [manual]
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
   rev: v4.0.1
   hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -74,27 +74,21 @@ deps =
   setuptools>=51.1.1
 skip_install = true
 commands =
-  # --no-annotate is used in order to prevent conflicts with PRs produced by dependency-bot
-  pip-compile --no-annotate --output-file=test-requirements.txt setup.py test-requirements.in
-  pip-compile --no-annotate --output-file=docs/requirements.txt setup.py docs/requirements.in
-  {envpython} -m pre_commit run {posargs:--all-files --show-diff-on-failure --hook-stage manual}
+  {envpython} -m pre_commit run --all-files --show-diff-on-failure {posargs:}
 passenv =
   {[testenv]passenv}
   PRE_COMMIT_HOME
 
 [testenv:deps]
 description = Bump all test depeendencies
-basepython = python3
-deps =
-  pre-commit>=2.6.0
-  pip-tools>=6.2.0
-  setuptools>=51.1.1
+# we reuse the lint environment
+envdir = {toxworkdir}/lint
 skip_install = true
+deps = {[testenv:lint]deps}
 commands =
-  # --no-annotate is used in order to prevent conflicts with PRs produced by dependency-bot
-  pip-compile --upgrade --no-annotate --output-file=test-requirements.txt setup.py test-requirements.in
-  pip-compile --upgrade --no-annotate --output-file=docs/requirements.txt setup.py docs/requirements.in
-  {envpython} -m pre_commit run {posargs:--all-files --hook-stage manual -v}
+  # manual hook calls the optional pip-compile-upgrade hook
+  {[testenv:lint]commands} --hook-stage manual pip-compile-upgrade
+  {[testenv:lint]commands} --hook-stage manual pip-compile-docs-upgrade
 
 [testenv:docs]
 description = Builds docs


### PR DESCRIPTION
- simplify execution logic of pip-compile
- remove pip-compile duplication between lint and deps tox envs.