### PR TITLE
fix: deterministic behaviour of cache installation in prerun

### DIFF
--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -263,7 +263,7 @@ def _symlink_galaxy_install(link_path: pathlib.Path) -> None:
 
 def _install_galaxy_role() -> None:
     """Detect standalone galaxy role and installs it."""
-    galaxy_path = "%s/meta/main.yml" % options.project_dir
+    galaxy_path = f"{options.project_dir}/meta/main.yml"
     if not os.path.exists(galaxy_path):
         return
     yaml = yaml_from_file(galaxy_path)
@@ -274,9 +274,8 @@ def _install_galaxy_role() -> None:
 
     if 'role-name' not in options.skip_list:
         if not re.match(r"[a-z0-9][a-z0-9_]+\.[a-z][a-z0-9_]+$", fqrn):
-            msg = (
-                """\
-Computed fully qualified role name of %s does not follow current galaxy requirements.
+            msg = f"""
+Computed fully qualified role name of {fqrn} does not follow current galaxy requirements.
 Please edit meta/main.yml and assure we can correctly determine full role name:
 
 galaxy_info:
@@ -288,8 +287,6 @@ Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
 
 As an alternative, you can add 'role-name' to either skip_list or warn_list.
 """
-                % fqrn
-            )
             if 'role-name' in options.warn_list:
                 _logger.warning(msg)
             else:
@@ -315,7 +312,7 @@ As an alternative, you can add 'role-name' to either skip_list or warn_list.
 
 def _install_galaxy_collection() -> None:
     """Detect standalone galaxy collection and installs it."""
-    galaxy_path = "%s/galaxy.yml" % options.project_dir
+    galaxy_path = f"{options.project_dir}/galaxy.yml"
     if not os.path.exists(galaxy_path):
         return
     yaml = yaml_from_file(galaxy_path)

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -334,10 +334,10 @@ def _prepare_ansible_paths() -> None:
     roles_path: List[str] = []
 
     for path_list, path in (
-        (library_paths, "plugins/modules"),
+        (library_paths, f"{options.project_dir}/plugins/modules"),
         (library_paths, f"{options.cache_dir}/modules"),
         (collection_list, f"{options.cache_dir}/collections"),
-        (roles_path, "roles"),
+        (roles_path, f"{options.project_dir}/roles"),
         (roles_path, f"{options.cache_dir}/roles"),
     ):
         if path not in path_list and os.path.exists(path):

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -258,9 +258,10 @@ def _symlink_galaxy_install(link_path) -> None:
 
 def _install_galaxy_role() -> None:
     """Detect standalone galaxy role and installs it."""
-    if not os.path.exists("meta/main.yml"):
+    galaxy_path = "%s/meta/main.yml" % options.project_dir
+    if not os.path.exists(galaxy_path):
         return
-    yaml = yaml_from_file("meta/main.yml")
+    yaml = yaml_from_file(galaxy_path)
     if 'galaxy_info' not in yaml:
         return
 
@@ -309,21 +310,17 @@ As an alternative, you can add 'role-name' to either skip_list or warn_list.
 
 def _install_galaxy_collection() -> None:
     """Detect standalone galaxy collection and installs it."""
-    if not os.path.exists("galaxy.yml"):
+    galaxy_path = "%s/galaxy.yml" % options.project_dir
+    if not os.path.exists(galaxy_path):
         return
-    yaml = yaml_from_file("galaxy.yml")
-    if not yaml:
-        # ignore empty galaxy.yml file
-        return
-    namespace = yaml.get('namespace', None)
-    collection = yaml.get('name', None)
-    if not namespace or not collection:
+    yaml = yaml_from_file(galaxy_path)
+    if 'namespace' not in yaml or 'name' not in yaml:
         return
     p = pathlib.Path(
-        f"{options.cache_dir}/collections/ansible_collections/{ namespace }"
+        f"{options.cache_dir}/collections/ansible_collections/{yaml['namespace']}"
     )
     p.mkdir(parents=True, exist_ok=True)
-    link_path = p / collection
+    link_path = p / yaml['name']
     _symlink_galaxy_install(link_path)
     _logger.info(
         "Using %s symlink to current repository in order to enable Ansible to find the collection using its expected full name.",

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -246,13 +246,18 @@ def _get_role_fqrn(galaxy_infos: Dict[str, Any]) -> str:
     return f"{role_namespace}{role_name}"
 
 
-def _symlink_galaxy_install(link_path) -> None:
-    # despite documentation stating that is_file() reports true for symlinks,
-    # it appears that is_dir() reports true instead, so we rely on exits().
-    target = pathlib.Path(options.project_dir).absolute()
-    if not link_path.exists() or os.readlink(link_path) != target:
-        if link_path.exists():
+def _symlink_galaxy_install(link_path: pathlib.Path) -> None:
+    target = str(pathlib.Path(options.project_dir).absolute())
+    if link_path.exists():
+        if link_path.is_symlink():
+            if os.readlink(str(link_path.absolute())) == target:
+                return
             link_path.unlink()
+        else:
+            raise RuntimeError(
+                "Can't replace non-symlink path '%s'" % link_path.absolute()
+            )
+
     link_path.symlink_to(target, target_is_directory=True)
 
 

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -77,11 +77,22 @@ def run_ansible_lint(
     env: Optional[Dict[str, str]] = None
 ) -> CompletedProcess:
     """Run ansible-lint on a given path and returns its output."""
+    project_dir = cwd
+    if project_dir is None:
+        project_dir = os.getcwd()
+
     if not executable:
         executable = sys.executable
-        args = [sys.executable, "-m", "ansiblelint", *argv]
+        args = [
+            sys.executable,
+            "-m",
+            "ansiblelint",
+            "--project-dir",
+            project_dir,
+            *argv,
+        ]
     else:
-        args = [executable, *argv]
+        args = [executable, "--project-dir", project_dir, *argv]
 
     # It is not safe to pass entire env for testing as other tests would
     # pollute the env, causing weird behaviors, so we pass only a safe list of

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -109,7 +109,7 @@ class TestCliRolePaths(unittest.TestCase):
         result = run_ansible_lint("-v", role_path, cwd=cwd)
         assert len(result.stdout) == 0
         assert (
-            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles"
+            f"Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:{self.local_test_dir}/roles"
             in result.stderr
         )
         assert result.returncode == 0
@@ -121,7 +121,7 @@ class TestCliRolePaths(unittest.TestCase):
         result = run_ansible_lint("-v", role_path, cwd=cwd)
         assert len(result.stdout) == 0
         assert (
-            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles"
+            f"Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:{self.local_test_dir}/roles"
             in result.stderr
         )
         assert result.returncode == 0


### PR DESCRIPTION
Ensure cache directory and environment are populated from `project_dir` and not from current working directory in `prerun` process.

Fixes: #1654