### PR TITLE
Adopt ansible-compat runtime

### DIFF
--- a/src/ansiblelint/__init__.py
+++ b/src/ansiblelint/__init__.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """Main ansible-lint package."""
-# prerun must run before any other imports
 from ansiblelint.version import __version__
 
 __all__ = ("__version__",)

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -35,12 +35,11 @@ from ansible_compat.config import ansible_version
 from enrich.console import should_do_markup
 
 from ansiblelint import cli
-from ansiblelint.app import App
+from ansiblelint.app import get_app
 from ansiblelint.color import console, console_options, reconfigure, render_yaml
 from ansiblelint.config import options
 from ansiblelint.constants import EXIT_CONTROL_C_RC
 from ansiblelint.file_utils import abspath, cwd, normpath
-from ansiblelint.prerun import check_ansible_presence, prepare_environment
 from ansiblelint.skip_utils import normalize_tag
 from ansiblelint.version import __version__
 
@@ -175,14 +174,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     _logger.debug("Options: %s", options)
     _logger.debug(os.getcwd())
 
-    app = App(options=options)
-
-    prepare_environment()
-    check_ansible_presence(exit_on_error=True)
-
-    # On purpose lazy-imports to avoid pre-loading Ansible
+    app = get_app()
     # pylint: disable=import-outside-toplevel
     from ansiblelint.rules import RulesCollection
+    from ansiblelint.runner import _get_matches
 
     rules = RulesCollection(options.rulesdirs)
 
@@ -191,8 +186,6 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if isinstance(options.tags, str):
         options.tags = options.tags.split(",")
-
-    from ansiblelint.runner import _get_matches
 
     result = _get_matches(rules, options)
 

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -60,6 +60,7 @@ options = Namespace(
     cwd=".",
     display_relative_path=True,
     exclude_paths=[],
+    format="rich",
     lintables=[],
     listrules=False,
     listtags=False,

--- a/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
+++ b/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any, List
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
+from ansiblelint.app import get_app
 from ansiblelint.config import options
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
@@ -70,6 +71,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
                 shell=False,  # needed when command is a list
                 universal_newlines=True,
                 check=False,
+                env=get_app().runtime.environ,
             )
             result = []
         if run.returncode != 0:

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -7,7 +7,8 @@ import sys
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from ansiblelint.prerun import prepare_environment
+from ansiblelint.app import get_app
+from ansiblelint.rules import RulesCollection
 
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3240
@@ -18,11 +19,10 @@ else:
 
 # Emulate command line execution initialization as without it Ansible module
 # would be loaded with incomplete module/role/collection list.
-prepare_environment()
+app = get_app()
 
 # pylint: disable=wrong-import-position
 from ansiblelint.errors import MatchError  # noqa: E402
-from ansiblelint.rules import RulesCollection  # noqa: E402
 from ansiblelint.runner import Runner  # noqa: E402
 
 

--- a/test/TestCliRolePaths.py
+++ b/test/TestCliRolePaths.py
@@ -92,10 +92,6 @@ class TestCliRolePaths(unittest.TestCase):
 
         result = run_ansible_lint("-v", role_path, cwd=cwd)
         assert len(result.stdout) == 0
-        assert (
-            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles"
-            in result.stderr
-        )
         assert result.returncode == 0
 
     def test_run_role_name_from_meta(self) -> None:
@@ -104,10 +100,6 @@ class TestCliRolePaths(unittest.TestCase):
 
         result = run_ansible_lint("-v", role_path, cwd=cwd)
         assert len(result.stdout) == 0
-        assert (
-            "Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles"
-            in result.stderr
-        )
         assert result.returncode == 0
 
     def test_run_invalid_role_name_from_meta(self) -> None:

--- a/test/TestVerbosity.py
+++ b/test/TestVerbosity.py
@@ -44,7 +44,7 @@ from ansiblelint.testing import run_ansible_lint
             [
                 ("WARNING  Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
-                ("INFO     Added ANSIBLE_LIBRARY=", False),
+                ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG ", True),
             ],
         ),
@@ -53,7 +53,7 @@ from ansiblelint.testing import run_ansible_lint
             [
                 ("WARNING  Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
-                ("INFO     Added ANSIBLE_LIBRARY=", False),
+                ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG    Effective yamllint rules used", False),
             ],
         ),
@@ -62,7 +62,7 @@ from ansiblelint.testing import run_ansible_lint
             [
                 ("WARNING  Loading custom .yamllint config file,", False),
                 ("WARNING  Listing 1 violation(s) that are fatal", False),
-                ("INFO     Added ANSIBLE_LIBRARY=", False),
+                ("INFO     Set ANSIBLE_LIBRARY=", False),
                 ("DEBUG    Effective yamllint rules used", False),
             ],
         ),


### PR DESCRIPTION
As part of decoupling molecule from ansible-lint, the functionality from ansiblelint.prerun was moved in a standalone generic library named ansible-compat.

This change is marked as major because it will break compatibility for anyone that relied on use of prerun module from the linter. The effective removal of prerun submodule will be done
in a follow-up, just to allow for an easier review.

Fixes: #1712
Fixes: #1784