### PR TITLE
Assure variable naming rule always use a pattern

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -327,7 +327,6 @@ def merge_config(file_config: Dict[Any, Any], cli_config: Namespace) -> Namespac
     scalar_map = {
         "loop_var_prefix": None,
         "project_dir": ".",
-        "var_naming_pattern": "^[a-z_][a-z0-9_]*$",
     }
 
     if not file_config:

--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -44,7 +44,7 @@ class VariableNamingRule(AnsibleLintRule):
 
     @lru_cache()
     def re_pattern(self) -> Pattern[str]:
-        return re.compile(options.var_naming_pattern)
+        return re.compile(options.var_naming_pattern or "^[a-z_][a-z0-9_]*$")
 
     def is_invalid_variable_name(self, ident: str) -> bool:
         """Check if variable name is using right pattern."""


### PR DESCRIPTION
Fixes bug which made the rule raise an error when options were not initialized (var_naming_pattern being None).