### PR TITLE
Add a Darglint config

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,0 +1,4 @@
+[darglint]
+docstring_style=sphinx
+enable=DAR104
+strictness=long


### PR DESCRIPTION
This pre-configures settings for a linting tool that checks if
all the function args are documented in their docstrings.