### PR TITLE
Expand coverage of path globbing

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,7 @@
 # .ansible-lint
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option will be parsed relative to the CWD of execution.
 exclude_paths:
 - .cache/  # implicit unless exclude_paths is defined in config
 - .github/

--- a/examples/playbooks/valid_with_alt_extension.yaml
+++ b/examples/playbooks/valid_with_alt_extension.yaml
@@ -1,0 +1,5 @@
+# Used to validate that we also accept .yaml extension on playbooks
+- hosts: localhost
+  tasks:
+    - debug:  # <-- should notify about missing 'name'
+        msg: "hello!"

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -4,6 +4,7 @@ import multiprocessing
 import multiprocessing.pool
 import os
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, FrozenSet, Generator, List, Optional, Set, Union
 
@@ -91,7 +92,8 @@ class Runner:
         _file_path = Path(file_path)
 
         return any(
-            abs_path.startswith(path) or _file_path.match(path)
+            abs_path.startswith(path) or _file_path.match(path) or
+            fnmatch(abs_path, path) or fnmatch(_file_path, path)
             for path in self.exclude_paths
         )
 

--- a/src/ansiblelint/runner.py
+++ b/src/ansiblelint/runner.py
@@ -92,8 +92,10 @@ class Runner:
         _file_path = Path(file_path)
 
         return any(
-            abs_path.startswith(path) or _file_path.match(path) or
-            fnmatch(abs_path, path) or fnmatch(_file_path, path)
+            abs_path.startswith(path)
+            or _file_path.match(path)
+            or fnmatch(str(abs_path), path)
+            or fnmatch(str(_file_path), path)
             for path in self.exclude_paths
         )
 

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -77,20 +77,21 @@ def test_runner_exclude_paths(default_rules_collection: RulesCollection) -> None
 
 
 @pytest.mark.parametrize(
-    ('exclude_path'), ('**/example.yml', 'examples/**/example.yml')
+    ('exclude_path'), ('**/playbooks/*.yml',)
 )
 def test_runner_exclude_globs(
     default_rules_collection: RulesCollection, exclude_path: str
 ) -> None:
     """Test that globs work."""
     runner = Runner(
-        'examples/playbooks/example.yml',
+        'examples/playbooks',
         rules=default_rules_collection,
         exclude_paths=[exclude_path],
     )
+    # breakpoint()
 
     matches = runner.run()
-    assert len(matches) == 0
+    assert len(matches) == 1
 
 
 @pytest.mark.parametrize(

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -76,12 +76,19 @@ def test_runner_exclude_paths(default_rules_collection: RulesCollection) -> None
     assert len(matches) == 0
 
 
-def test_runner_exclude_globs(default_rules_collection: RulesCollection) -> None:
+@pytest.mark.parametrize(
+    ('exclude_path'),
+    (
+        '**/example.yml',
+        'examples/**/example.yml'
+    )
+)
+def test_runner_exclude_globs(default_rules_collection: RulseCollection, exclude_path) -> None:
     """Test that globs work."""
     runner = Runner(
         'examples/playbooks/example.yml',
         rules=default_rules_collection,
-        exclude_paths=['**/example.yml'],
+        exclude_paths=[exclude_path],
     )
 
     matches = runner.run()

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -77,13 +77,11 @@ def test_runner_exclude_paths(default_rules_collection: RulesCollection) -> None
 
 
 @pytest.mark.parametrize(
-    ('exclude_path'),
-    (
-        '**/example.yml',
-        'examples/**/example.yml'
-    )
+    ('exclude_path'), ('**/example.yml', 'examples/**/example.yml')
 )
-def test_runner_exclude_globs(default_rules_collection: RulseCollection, exclude_path) -> None:
+def test_runner_exclude_globs(
+    default_rules_collection: RulesCollection, exclude_path: str
+) -> None:
     """Test that globs work."""
     runner = Runner(
         'examples/playbooks/example.yml',

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -76,9 +76,7 @@ def test_runner_exclude_paths(default_rules_collection: RulesCollection) -> None
     assert len(matches) == 0
 
 
-@pytest.mark.parametrize(
-    ('exclude_path'), ('**/playbooks/*.yml',)
-)
+@pytest.mark.parametrize(('exclude_path'), ('**/playbooks/*.yml',))
 def test_runner_exclude_globs(
     default_rules_collection: RulesCollection, exclude_path: str
 ) -> None:

--- a/test/TestRunner.py
+++ b/test/TestRunner.py
@@ -88,9 +88,9 @@ def test_runner_exclude_globs(
         rules=default_rules_collection,
         exclude_paths=[exclude_path],
     )
-    # breakpoint()
 
     matches = runner.run()
+    # we expect to find one error from the only .yaml file we have there.
     assert len(matches) == 1
 
 


### PR DESCRIPTION
Exclude path handling does not pick up very many glob matches. This
improves the matching by adding in fnmatch module usage

Fixes: #1561