### PR TITLE
Minor fixes on documentation pages

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -58,7 +58,7 @@ using ``--user`` or fixing potential conflicts if not using virtualenvs.
 
 .. _installing_from_source:
 .. _pip3: https://pypi.org/project/pip/
-.. _pipx: https://pipxproject.github.io/pipx/
+.. _pipx: https://pypa.github.io/pipx/
 
 From Source
 -----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -57,7 +57,7 @@ CI/CD
 -----
 
 If execution under `Github Actions`_ is detected via the presence of
-``GITHUB_ACTIONS=true`` and ``GITHUB_WORFLOW=...`` variables, the linter will
+``GITHUB_ACTIONS=true`` and ``GITHUB_WORKFLOW=...`` variables, the linter will
 also print errors using their `annotation`_ format.
 
 .. _GitHub Actions: https://github.com/features/actions

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,7 +30,7 @@ As part of the execution, the linter will likely need to create a cache of
 installed or mocked roles, collections and modules. This is done inside
 ``{project_dir}/.cache`` folder. The project directory is either given as a
 command line argument, determined by location of the configuration
-file, git project top-level directiory or user home directory as fallback.
+file, git project top-level directory or user home directory as fallback.
 In order to speed-up reruns, the linter does not clean this folder by itself.
 
 If you are using git, you will likely want to add this folder to your


### PR DESCRIPTION
This PR just fix some minor typos/spelling errors I found when I was reading the documentation site.

At first, I just wanted to try the Github Actions env vars, but after doing a copy/paste on my terminal I found out that there was a typo on the `GITHUB_WORKFLOW` variable name, so to avoid just creating a pull request with only a new byte on it I also run `aspell check` on all the `*.rst` files under `docs/` and I check all the URLs.

I didn't find any open issues related to this but I can open a new issue if you want.

Please feel free to request any changes or drop this PR if it's not relevant. Thanks