### PR TITLE
Make core extra use ansible-core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
     args: ["--strict"]
     additional_dependencies:
     - Sphinx>=3.1.2
-    - ansible-base
+    - ansible-core
     - enrich
     - flaky
     - pytest
@@ -107,7 +107,7 @@ repos:
   hooks:
   - id: pylint
     additional_dependencies:
-    - ansible-base
+    - ansible-core
     - docutils
     - enrich
     - flaky

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -29,8 +29,8 @@ related to containers and use the discussions_ forum instead.
     specific version of Ansible. You need to either install the desired version
     of Ansible yourself or mention one of the helper extras:
 
-    * ``core`` - will install the latest version of ansible-base 2.10
-    * ``community`` - will install the latest version of ansible 2.10 with community collections
+    * ``core`` - will install the latest version of ansible-core 2.11+
+    * ``community`` - will install the latest version of ansible community edition
 
 Using pip or pipx
 -----------------

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,4 +1,4 @@
-ansible-base  # needed by rules_table_generator
+ansible-core  # needed by rules_table_generator
 myst-parser
 pipdeptree
 pytest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --extra=yamllint --no-annotate --output-file=docs/requirements.txt docs/requirements.in setup.cfg
 #
 alabaster==0.7.12
-ansible-base==2.10.13
+ansible-core==2.11.4
 ansible-pygments==0.1.0
 attrs==21.2.0
 babel==2.9.1
@@ -39,6 +39,7 @@ pytest==6.2.4
 pytz==2021.1
 pyyaml==5.4.1
 requests==2.26.0
+resolvelib==0.5.4
 rich==10.7.0
 ruamel.yaml==0.17.11 ; python_version >= "3.7"
 ruamel.yaml.clib==0.2.6

--- a/examples/roles/dependency_in_meta/meta/main.yml
+++ b/examples/roles/dependency_in_meta/meta/main.yml
@@ -22,7 +22,7 @@ dependencies:
     name: nginx_role
 
   # from GitLab or other git-based scm
-  - src: git@gitlab.company.com:mygroup/ansible-base.git
+  - src: git@gitlab.company.com:mygroup/myrepo.git
     scm: git
     version: "0.1"  # quoted, so YAML doesn't parse this as a floating-point value
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ community =
   ansible>=2.10  # GPLv3+
 # this will move to latest stable ansible as soon that is released
 core =
-  ansible-base>=2.10  # GPLv3+
+  ansible-core>=2.11.4  # GPLv3+
 # will install ansible from devel branch, may break at any moment.
 ; Disabled due to https://github.com/pypa/twine/issues/726
 ; devel =

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ description =
   Run the tests under {basepython} and
   devel: ansible devel branch
   ansible29: ansible 2.9
-  core: ansible-base 2.10
-  py: ansible-core 2.11
+  core: ansible-core 2.11+
 extras =
   yamllint
   core: core


### PR DESCRIPTION
Instead of installing `ansible-base` when `core` extra is
used, we will require `ansible-core`. When original change was
introduced few months back we already knew that the future
proof name was `core` so that is with the extra was called as
such.

Users that want to explicitly use ansible 2.10 should avoid using the extra and mention ansible as a separated dependency. 

If previous environments already existed with ansible-base installed on them an installation failure will appear as ansible-base needs to be removed before ansible-core is installed. Due to this, this change will only be include in the next `5.2.0` release instead of being considered a simple bugfix.

Fixes: #1717