### PR TITLE
improve grammar

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -103,7 +103,7 @@ class AnsibleParserErrorRule(BaseRule):
 
     id = 'parser-error'
     shortdesc = 'AnsibleParserError'
-    description = 'Ansible parser fails, this usually indicate invalid file.'
+    description = 'Ansible parser fails; this usually indicates an invalid file.'
     severity = 'VERY_HIGH'
     tags = ['core']
     version_added = 'v5.0.0'

--- a/src/ansiblelint/rules/NoSameOwnerRule.py
+++ b/src/ansiblelint/rules/NoSameOwnerRule.py
@@ -13,7 +13,7 @@ class NoSameOwnerRule(AnsibleLintRule):
     id = 'no-same-owner'
     shortdesc = 'Owner should not be kept between different hosts'
     description = """
-Optional rule that hihglight dangers of assuming that user/group on the remote
+Optional rule that highlights dangers of assuming that user/group on the remote
 machines may not exist on ansible controller or vice versa. Owner and group
 should not be preserved when transferring files between them.
 


### PR DESCRIPTION
A grammar-lint for ansible-lint, fixing the two worst documentation typos.