### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @ssbarnea
+*       @ansible-community/devtools


### PR DESCRIPTION
Use devtools team assignment for reviews, making reviews easier and faster.

Related: https://github.community/t/question-add-team-for-codeowners-from-other-organization/3069