### PR TITLE
Prevent parseable option from changing JSON output format

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -73,10 +73,10 @@ def choose_formatter_factory(
         r = formatters.QuietFormatter
     elif options_list.parseable_severity:
         r = formatters.ParseableSeverityFormatter
-    elif options_list.parseable or options_list.format == 'pep8':
-        r = formatters.ParseableFormatter
     elif options_list.format == 'codeclimate':
         r = formatters.CodeclimateJSONFormatter
+    elif options_list.parseable or options_list.format == 'pep8':
+        r = formatters.ParseableFormatter
     return r
 
 

--- a/test/TestCodeclimateJSONFormatter.py
+++ b/test/TestCodeclimateJSONFormatter.py
@@ -1,6 +1,8 @@
 """Test the codeclimate JSON formatter."""
 import json
 import pathlib
+import subprocess
+import sys
 from typing import List, Optional
 
 import pytest
@@ -86,3 +88,20 @@ class TestCodeclimateJSONFormatter:
         assert single_match['location']['path'] == self.matches[0].filename
         assert 'lines' in single_match['location']
         assert single_match['location']['lines']['begin'] == self.matches[0].linenumber
+
+
+def test_code_climate_parsable_ignored() -> None:
+    """Test that -p option does not alter codeclimate format."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "ansiblelint",
+        "-v",
+        "-p",
+    ]
+    file = "examples/playbooks/empty_playbook.yml"
+    result = subprocess.run([*cmd, file], check=False)
+    result2 = subprocess.run([*cmd, "-p", file], check=False)
+
+    assert result.returncode == result2.returncode
+    assert result.stdout == result2.stdout


### PR DESCRIPTION
This bug was originally reported against ansible-language-server but
it proved to be caused by a bug inside the linter.

Fixes: https://github.com/ansible/ansible-language-server/issues/43