### PR TITLE
Avoid testing with ansible devel on py36/py37

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -126,9 +126,11 @@ jobs:
         - tox_env: py38
           os: ubuntu-20.04
           python-version: 3.8
+          devel: true
         - tox_env: py39
           os: ubuntu-20.04
           python-version: 3.9
+          devel: true
         - tox_env: py36
           os: macOS-latest
           python-version: 3.6
@@ -184,7 +186,7 @@ jobs:
         --skip-missing-interpreters false
         -vv
       env:
-        TOXENV: ${{ matrix.tox_env }}-core,${{ matrix.tox_env }}-ansible29,${{ matrix.tox_env }}-devel
+        TOXENV: ${{ matrix.tox_env }}-core,${{ matrix.tox_env }}-ansible29
     # sequential run improves browsing experience (almost no speed impact)
     - name: "Test with tox: ${{ matrix.tox_env }}-core"
       run: |
@@ -197,6 +199,7 @@ jobs:
       env:
         TOXENV: ${{ matrix.tox_env }}-ansible29
     - name: "Test with tox: ${{ matrix.tox_env }}-devel"
+      if: ${{ matrix.devel }}
       run: |
         python3 -m tox
       env:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 minversion = 3.16.1
-envlist = lint,packaging,py{39,38,37,36}-{core,ansible29,devel}
+envlist =
+  lint
+  packaging
+  py{39,38}-{core,ansible29,devel}
+  py{37,36}-{core,ansible29}
 isolated_build = true
 requires =
   setuptools >= 41.4.0


### PR DESCRIPTION
As recently ansible devel branch dropped support for py36/py37 we no longer test it on those versions.

This is fixing the CI which is currently broken since https://github.com/ansible/ansible/pull/74013 was merged.