### PR TITLE
Add HOME to safe env vars

### DIFF
--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -87,6 +87,7 @@ def run_ansible_lint(
     # pollute the env, causing weird behaviors, so we pass only a safe list of
     # vars.
     safe_list = [
+        'HOME',
         'LANG',
         'LC_ALL',
         'LC_CTYPE',


### PR DESCRIPTION
Some build systems, such as nix, will modify HOME env var to provide a
writable home dir.

If the modify HOME env var is cleared, and the original home dir of the
build user is not writable, some tests will fail.

Failed build log of ansible-lint on nix aarch64-darwin https://hydra.nixos.org/build/157038092/nixlog/1