### PR TITLE
docs: Add missing type and parameter in custom-rules.rst

### DIFF
--- a/docs/custom-rules.rst
+++ b/docs/custom-rules.rst
@@ -46,7 +46,7 @@ An example rule using ``matchtask`` is:
 
 .. code-block:: python
 
-    from typing import Any, Dict
+    from typing import Any, Dict, Union
 
     import ansiblelint.utils
     from ansiblelint.rules import AnsibleLintRule
@@ -57,7 +57,7 @@ An example rule using ``matchtask`` is:
         description = 'Tasks must have tag'
         tags = ['productivity']
 
-        def matchtask(self, task: Dict[str, Any]) -> Union[bool,str]:
+        def matchtask(self, task: Dict[str, Any], file) -> Union[bool,str]:
             # If the task include another task or make the playbook fail
             # Don't force to have a tag
             if not set(task.keys()).isdisjoint(['include','fail']):

--- a/docs/custom-rules.rst
+++ b/docs/custom-rules.rst
@@ -46,10 +46,15 @@ An example rule using ``matchtask`` is:
 
 .. code-block:: python
 
-    from typing import Any, Dict, Union
+    from typing import TYPE_CHECKING, Any, Dict, Union
 
     import ansiblelint.utils
     from ansiblelint.rules import AnsibleLintRule
+
+    if TYPE_CHECKING:
+        from typing import Optional
+
+        from ansiblelint.file_utils import Lintable
 
     class TaskHasTag(AnsibleLintRule):
         id = 'EXAMPLE001'
@@ -57,7 +62,7 @@ An example rule using ``matchtask`` is:
         description = 'Tasks must have tag'
         tags = ['productivity']
 
-        def matchtask(self, task: Dict[str, Any], file) -> Union[bool,str]:
+        def matchtask(self, task: Dict[str, Any], file: 'Optional[Lintable]' = None) -> Union[bool,str]:
             # If the task include another task or make the playbook fail
             # Don't force to have a tag
             if not set(task.keys()).isdisjoint(['include','fail']):


### PR DESCRIPTION
Hello there! :wave: 

When trying to write some new custom rules, we found out a couple of minor mistakes in the documentation, so figured out we will open a PR to fix those.

I didn't add the type of `file` as it requires another import (`from ansiblelint.file_utils import Lintable`) but I can do that if it is necessary for you!