### PR TITLE
Make exclude files work with progressive mode

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -44,7 +44,7 @@ from ansiblelint.color import (
 )
 from ansiblelint.config import options
 from ansiblelint.constants import ANSIBLE_MISSING_RC, EXIT_CONTROL_C_RC
-from ansiblelint.file_utils import cwd
+from ansiblelint.file_utils import abspath, cwd, normpath
 from ansiblelint.prerun import check_ansible_presence, prepare_environment
 from ansiblelint.skip_utils import normalize_tag
 from ansiblelint.version import __version__
@@ -278,6 +278,13 @@ def main(argv: Optional[List[str]] = None) -> int:
 def _previous_revision() -> Iterator[None]:
     """Create or update a temporary workdir containing the previous revision."""
     worktree_dir = f"{options.cache_dir}/old-rev"
+    """ Update options.exclude_paths to include use the temporary workdir."""
+    rel_exclude_paths = []
+    for exclude_path in options.exclude_paths:
+        rel_exclude_paths.append(normpath(exclude_path))
+    options.exclude_paths = []
+    for exclude_path in rel_exclude_paths:
+        options.exclude_paths.append(abspath(exclude_path, worktree_dir))
     revision = subprocess.run(
         ["git", "rev-parse", "HEAD^1"],
         check=True,
@@ -288,9 +295,14 @@ def _previous_revision() -> Iterator[None]:
     p = pathlib.Path(worktree_dir)
     p.mkdir(parents=True, exist_ok=True)
     os.system(f"git worktree add -f {worktree_dir} 2>/dev/null")
-    with cwd(worktree_dir):
-        os.system(f"git checkout {revision}")
-        yield
+    try:
+        with cwd(worktree_dir):
+            os.system(f"git checkout {revision}")
+            yield
+    finally:
+        options.exclude_paths = []
+        for exclude_path in rel_exclude_paths:
+            options.exclude_paths.append(abspath(exclude_path, os.getcwd()))
 
 
 def _run_cli_entrypoint() -> None:

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -278,7 +278,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 def _previous_revision() -> Iterator[None]:
     """Create or update a temporary workdir containing the previous revision."""
     worktree_dir = f"{options.cache_dir}/old-rev"
-    """ Update options.exclude_paths to include use the temporary workdir."""
+    # Update options.exclude_paths to include use the temporary workdir.
     rel_exclude_paths = []
     for exclude_path in options.exclude_paths:
         rel_exclude_paths.append(normpath(exclude_path))

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -279,12 +279,8 @@ def _previous_revision() -> Iterator[None]:
     """Create or update a temporary workdir containing the previous revision."""
     worktree_dir = f"{options.cache_dir}/old-rev"
     # Update options.exclude_paths to include use the temporary workdir.
-    rel_exclude_paths = []
-    for exclude_path in options.exclude_paths:
-        rel_exclude_paths.append(normpath(exclude_path))
-    options.exclude_paths = []
-    for exclude_path in rel_exclude_paths:
-        options.exclude_paths.append(abspath(exclude_path, worktree_dir))
+    rel_exclude_paths = [normpath(p) for p in options.exclude_paths]
+    options.exclude_paths = [abspath(p, worktree_dir) for p in rel_exclude_paths]
     revision = subprocess.run(
         ["git", "rev-parse", "HEAD^1"],
         check=True,
@@ -300,9 +296,7 @@ def _previous_revision() -> Iterator[None]:
             os.system(f"git checkout {revision}")
             yield
     finally:
-        options.exclude_paths = []
-        for exclude_path in rel_exclude_paths:
-            options.exclude_paths.append(abspath(exclude_path, os.getcwd()))
+        options.exclude_paths = [abspath(p, os.getcwd()) for p in rel_exclude_paths]
 
 
 def _run_cli_entrypoint() -> None:

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -200,6 +200,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     initialize_logger(options.verbosity)
     _logger.debug("Options: %s", options)
+    _logger.debug(os.getcwd())
 
     app = App(options=options)
 
@@ -241,6 +242,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             "Matches found, running again on previous revision in order to detect regressions"
         )
         with _previous_revision():
+            _logger.debug("Options: %s", options)
+            _logger.debug(os.getcwd())
             old_result = _get_matches(rules, options)
             # remove old matches from current list
             matches_delta = list(set(result.matches) - set(old_result.matches))


### PR DESCRIPTION
If `options.progressive` is set, `options.exclude_files` are not updated in `_previous-revision`, rendering them useless. This pull requests handles that.

Fixes: #1766