### PR TITLE
Fix mypy failures on file_utils.py

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -78,7 +78,7 @@ def kind_from_path(path: Path, base: bool = False) -> FileType:
     """
     # pathlib.Path.match patterns are very limited, they do not support *a*.yml
     # glob.glob supports **/foo.yml but not multiple extensions
-    pathex = wcmatch.pathlib.PurePath(path.absolute().resolve())
+    pathex = wcmatch.pathlib.PurePath(str(path.absolute().resolve()))
     kinds = options.kinds if not base else BASE_KINDS
     for entry in kinds:
         for k, v in entry.items():
@@ -245,9 +245,11 @@ def discover_lintables(options: Namespace) -> Dict[str, Any]:
     if out is None:
         exclude_pattern = "|".join(str(x) for x in options.exclude_paths)
         _logger.info("Looking up for files, excluding %s ...", exclude_pattern)
-        out = WcMatch(
-            '.', exclude_pattern=exclude_pattern, flags=RECURSIVE, limit=256
-        ).match()
+        out = set(
+            WcMatch(
+                '.', exclude_pattern=exclude_pattern, flags=RECURSIVE, limit=256
+            ).match()
+        )
 
     return OrderedDict.fromkeys(sorted(out))
 


### PR DESCRIPTION
While working to move abspath from `cli.py` to `file_utils.py`, I got hit by pre-commit failure in `mypy` hook:

```
src/ansiblelint/file_utils.py:82: error: Argument 1 to "PurePath" has incompatible type "Path"; expected "str"
src/ansiblelint/file_utils.py:249: error: Incompatible types in assignment (expression has type "List[Any]", variable has type "Optional[Set[str]]")
src/ansiblelint/file_utils.py:253: error: Argument 1 to "sorted" has incompatible type "Optional[Set[str]]"; expected "Iterable[str]"
Found 3 errors in 1 file (checked 1 source file)
```

This should fix those errors.