### PR TITLE
Avoid errors processing symlinked files

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -201,7 +201,7 @@ class Lintable:
     def content(self) -> str:
         """Retried file content, from internal cache or disk."""
         if self._content is None:
-            with open(self.path, mode='r', encoding='utf-8') as f:
+            with open(self.path.resolve(), mode='r', encoding='utf-8') as f:
                 self._content = f.read()
         return self._content
 


### PR DESCRIPTION
Fixes bug where linter will fail to process symlinked files because
it failed to retrieve the content of the lintable.

This bug was observed on our "eco" pipeline.
Related: https://github.com/devroles/ansible_collection_system/pull/8#pullrequestreview-817978598