### PR TITLE
Make -q and -qq silence ANSIBLE_DEVEL_WARNING

### DIFF
--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -328,7 +328,7 @@ def _prepare_ansible_paths() -> None:
     # Ansible warnings which could slip through, namely the devel branch
     # warning.
     if options.verbosity < 0:
-        _update_env("ANSIBLE_DEVEL_WARNING", "False")
+        _update_env("ANSIBLE_DEVEL_WARNING", ["False"])
 
 def _make_module_stub(module_name: str) -> None:
     # a.b.c is treated a collection

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -324,6 +324,11 @@ def _prepare_ansible_paths() -> None:
     _update_env(ansible_collections_path(), collection_list)
     _update_env('ANSIBLE_ROLES_PATH', roles_path, default=ANSIBLE_DEFAULT_ROLES_PATH)
 
+    # If we are asking to run without warnings, then also silence certain
+    # Ansible warnings which could slip through, namely the devel branch
+    # warning.
+    if options.verbosity < 0:
+        _update_env("ANSIBLE_DEVEL_WARNING", "False")
 
 def _make_module_stub(module_name: str) -> None:
     # a.b.c is treated a collection

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -330,6 +330,7 @@ def _prepare_ansible_paths() -> None:
     if options.verbosity < 0:
         _update_env("ANSIBLE_DEVEL_WARNING", ["False"])
 
+
 def _make_module_stub(module_name: str) -> None:
     # a.b.c is treated a collection
     if re.match(r"^(\w+|\w+\.\w+\.[\.\w]+)$", module_name):


### PR DESCRIPTION
Change:
- Per title -- when passing -q and -qq to silence warnings, also silence
  Ansible's devel branch warning when running Ansible from devel.

Test Plan:
- Tested locally where I use devel by default.

Signed-off-by: Rick Elrod <rick@elrod.me>