### PR TITLE
Allow rpm --nodeps command-instead-of-module

### DIFF
--- a/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -69,7 +69,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         'git': ['branch', 'log'],
         'systemctl': ['set-default', 'show-environment', 'status'],
         'yum': ['clean'],
-        'rpm': ['-e'],
+        'rpm': ['--nodeps'],
     }
 
     def matchtask(

--- a/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
+++ b/src/ansiblelint/rules/CommandsInsteadOfModulesRule.py
@@ -69,6 +69,7 @@ class CommandsInsteadOfModulesRule(AnsibleLintRule):
         'git': ['branch', 'log'],
         'systemctl': ['set-default', 'show-environment', 'status'],
         'yum': ['clean'],
+        'rpm': ['-e'],
     }
 
     def matchtask(


### PR DESCRIPTION
Running `command rpm -e [...]` causes a failure due to rule `command-instead-of-module`. But the `yum` module does not support "expunge" action, so the suggestion to use it is invalid.

Edit `command-instead-of-module` rule to add `rpm -e` to commands that skip the suggestion to use `yum` module instead of `command`.
