### PR TITLE
Instruct pytest to pre-load the `cov` plugin early

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
   {envpython} -m pytest \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
   {posargs:\
+    -p pytest_cov \
     --cov ansiblelint \
     --cov "{envsitepackagesdir}/ansiblelint" \
     --cov-report term-missing:skip-covered \


### PR DESCRIPTION
This is necessary because in some cases there's a race condition
with xdist and loading `pytest_cov` early mitigates that.

When present, the problem shows up like this:
```console
/Users/runner/work/ansible-lint/ansible-lint/.tox/py36-ansible29/lib/python3.6/site-packages/coverage/inorout.py:514: CoverageWarning: Module /Users/runner/work/ansible-lint/ansible-lint/.tox/py36-ansible29/lib/python3.6/site-packages/ansiblelint was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
```
_(excerpt from https://github.com/ansible-community/ansible-lint/runs/4608147625?check_suite_focus=true#step:10:37)_