### PR TITLE
fix: add a constraint of the rich version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ install_requires =
   enrich>=1.2.6
   packaging
   pyyaml
-  rich>=9.5.1
+  rich>=9.5.1,<11.0.0
   ruamel.yaml >= 0.15.34,<1; python_version < "3.7"
   ruamel.yaml >= 0.15.37,<1; python_version >= "3.7"
   # NOTE: per issue #509 0.15.34 included in debian backports


### PR DESCRIPTION
# What

* Add a constraint of the rich version

# Why

* ansible-lint failed due to the error: `ImportError: cannot import name 'render_group' from 'rich.console'` with `rich==11.0.0`.
* Please take a look at https://github.com/ansible-community/ansible-lint/issues/1795 for the details