### PR TITLE
Revert "Mark the `eco` job as allowed to fail"

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,8 +39,6 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
       FORCE_COLOR: 1
 
-    continue-on-error: ${{ matrix.env.TOXENV == 'eco' }}
-
     steps:
     - name: Check out src from Git
       uses: actions/checkout@v2


### PR DESCRIPTION
Reverts ansible-community/ansible-lint#1790