### PR TITLE
MatchError's should include the filename

### DIFF
--- a/src/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
+++ b/src/ansiblelint/rules/BecomeUserWithoutBecomeRule.py
@@ -22,6 +22,7 @@ from functools import reduce
 from typing import TYPE_CHECKING, Any, List
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import LINE_NUMBER_KEY
 
 if TYPE_CHECKING:
     from ansiblelint.constants import odict
@@ -102,7 +103,7 @@ class BecomeUserWithoutBecomeRule(AnsibleLintRule):
                     self.create_matcherror(
                         message=self.shortdesc,
                         filename=str(file.path),
-                        linenumber=data['__line__'],
+                        linenumber=data[LINE_NUMBER_KEY],
                     )
                 ]
         return []

--- a/src/ansiblelint/rules/MetaChangeFromDefaultRule.py
+++ b/src/ansiblelint/rules/MetaChangeFromDefaultRule.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, List
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import LINE_NUMBER_KEY
 
 if TYPE_CHECKING:
     from typing import Any
@@ -46,7 +47,7 @@ class MetaChangeFromDefaultRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         filename=file,
-                        linenumber=data['__line__'],
+                        linenumber=data[LINE_NUMBER_KEY],
                         message='Should change default metadata: %s' % field,
                     )
                 )

--- a/src/ansiblelint/rules/MetaTagValidRule.py
+++ b/src/ansiblelint/rules/MetaTagValidRule.py
@@ -45,30 +45,40 @@ class MetaTagValidRule(AnsibleLintRule):
                 tags += galaxy_info['galaxy_tags']
             else:
                 results.append(
-                    self.create_matcherror("Expected 'galaxy_tags' to be a list")
+                    self.create_matcherror(
+                        "Expected 'galaxy_tags' to be a list", filename=file
+                    )
                 )
 
         if 'categories' in galaxy_info:
             results.append(
-                self.create_matcherror("Use 'galaxy_tags' rather than 'categories'")
+                self.create_matcherror(
+                    "Use 'galaxy_tags' rather than 'categories'", filename=file
+                )
             )
             if isinstance(galaxy_info['categories'], list):
                 tags += galaxy_info['categories']
             else:
                 results.append(
-                    self.create_matcherror("Expected 'categories' to be a list")
+                    self.create_matcherror(
+                        "Expected 'categories' to be a list", filename=file
+                    )
                 )
 
         for tag in tags:
             msg = self.shortdesc
             if not isinstance(tag, str):
                 results.append(
-                    self.create_matcherror("Tags must be strings: '{}'".format(tag))
+                    self.create_matcherror(
+                        "Tags must be strings: '{}'".format(tag), filename=file
+                    )
                 )
                 continue
             if not re.match(self.TAG_REGEXP, tag):
                 results.append(
-                    self.create_matcherror(message="{}, invalid: '{}'".format(msg, tag))
+                    self.create_matcherror(
+                        message="{}, invalid: '{}'".format(msg, tag), filename=file
+                    )
                 )
 
         return results

--- a/src/ansiblelint/rules/MetaVideoLinksRule.py
+++ b/src/ansiblelint/rules/MetaVideoLinksRule.py
@@ -51,7 +51,8 @@ class MetaVideoLinksRule(AnsibleLintRule):
             if not isinstance(video, dict):
                 results.append(
                     self.create_matcherror(
-                        "Expected item in 'video_links' to be " "a dictionary"
+                        "Expected item in 'video_links' to be " "a dictionary",
+                        filename=file,
                     )
                 )
                 continue
@@ -60,7 +61,8 @@ class MetaVideoLinksRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         "Expected item in 'video_links' to contain "
-                        "only keys 'url' and 'title'"
+                        "only keys 'url' and 'title'",
+                        filename=file,
                     )
                 )
                 continue
@@ -74,6 +76,6 @@ class MetaVideoLinksRule(AnsibleLintRule):
                     "Expected it be a shared link from Vimeo, YouTube, "
                     "or Google Drive.".format(video['url'])
                 )
-                results.append(self.create_matcherror(msg))
+                results.append(self.create_matcherror(msg, filename=file))
 
         return results

--- a/src/ansiblelint/rules/MetaVideoLinksRule.py
+++ b/src/ansiblelint/rules/MetaVideoLinksRule.py
@@ -4,6 +4,7 @@ import re
 from typing import TYPE_CHECKING, List
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import FILENAME_KEY, LINE_NUMBER_KEY
 
 if TYPE_CHECKING:
     from typing import Any
@@ -57,7 +58,7 @@ class MetaVideoLinksRule(AnsibleLintRule):
                 )
                 continue
 
-            if set(video) != {'url', 'title', '__file__', '__line__'}:
+            if set(video) != {'url', 'title', FILENAME_KEY, LINE_NUMBER_KEY}:
                 results.append(
                     self.create_matcherror(
                         "Expected item in 'video_links' to contain "

--- a/src/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/src/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -34,7 +34,11 @@ class NoFormattingInWhenRule(AnsibleLintRule):
                 return errors
             for role in data['roles']:
                 if self.matchtask(role, file=file):
-                    errors.append(self.create_matcherror(details=str({'when': role})))
+                    errors.append(
+                        self.create_matcherror(
+                            details=str({'when': role}), filename=file
+                        )
+                    )
         if isinstance(data, list):
             for play_item in data:
                 sub_errors = self.matchplay(file, play_item)

--- a/src/ansiblelint/rules/NoFormattingInWhenRule.py
+++ b/src/ansiblelint/rules/NoFormattingInWhenRule.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import LINE_NUMBER_KEY
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -36,7 +37,9 @@ class NoFormattingInWhenRule(AnsibleLintRule):
                 if self.matchtask(role, file=file):
                     errors.append(
                         self.create_matcherror(
-                            details=str({'when': role}), filename=file
+                            details=str({'when': role}),
+                            filename=file,
+                            linenumber=role[LINE_NUMBER_KEY],
                         )
                     )
         if isinstance(data, list):

--- a/src/ansiblelint/rules/NoSameOwnerRule.py
+++ b/src/ansiblelint/rules/NoSameOwnerRule.py
@@ -6,6 +6,7 @@ from typing import Any, List
 from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import LINE_NUMBER_KEY
 
 
 class NoSameOwnerRule(AnsibleLintRule):
@@ -58,14 +59,14 @@ https://zuul-ci.org/docs/zuul-jobs/policy.html\
                 print(task)
                 results.append(
                     self.create_matcherror(
-                        filename=lintable, linenumber=task['__line__']
+                        filename=lintable, linenumber=task[LINE_NUMBER_KEY]
                     )
                 )
         elif 'unarchive' in task:
             if self.handle_unarchive(task):
                 results.append(
                     self.create_matcherror(
-                        filename=lintable, linenumber=task['__line__']
+                        filename=lintable, linenumber=task[LINE_NUMBER_KEY]
                     )
                 )
 

--- a/src/ansiblelint/rules/RoleLoopVarPrefix.py
+++ b/src/ansiblelint/rules/RoleLoopVarPrefix.py
@@ -6,6 +6,7 @@ from ansiblelint.errors import MatchError
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.text import toidentifier
+from ansiblelint.utils import LINE_NUMBER_KEY
 
 if TYPE_CHECKING:
     from typing import Any
@@ -82,7 +83,7 @@ Looping inside roles has the risk of clashing with loops from user-playbooks.\
             if not loop_var or not loop_var.startswith(self.prefix):
                 results.append(
                     self.create_matcherror(
-                        filename=lintable, linenumber=task['__line__']
+                        filename=lintable, linenumber=task[LINE_NUMBER_KEY]
                     )
                 )
         return results

--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Union
 from ansiblelint.config import options
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import parse_yaml_from_file
+from ansiblelint.utils import LINE_NUMBER_KEY, parse_yaml_from_file
 
 if TYPE_CHECKING:
     from ansiblelint.constants import odict
@@ -78,7 +78,7 @@ class VariableNamingRule(AnsibleLintRule):
                 results.append(
                     self.create_matcherror(
                         filename=file,
-                        linenumber=our_vars['__line__'],
+                        linenumber=our_vars[LINE_NUMBER_KEY],
                         message="Play defines variable '"
                         + key
                         + "' within 'vars' section that violates variable naming standards",
@@ -124,7 +124,7 @@ class VariableNamingRule(AnsibleLintRule):
                     results.append(
                         self.create_matcherror(
                             filename=file,
-                            # linenumber=vars['__line__'],
+                            # linenumber=vars[LINE_NUMBER_KEY],
                             message="File defines variable '"
                             + key
                             + "' that violates variable naming standards",

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -626,8 +626,8 @@ def task_to_str(task: Dict[str, Any]) -> str:
                 "__ansible_module__",
                 "__ansible_module_original__",
                 "__ansible_arguments__",
-                "__line__",
-                "__file__",
+                LINE_NUMBER_KEY,
+                FILENAME_KEY,
             ]
         ]
     )


### PR DESCRIPTION
Whenever possible, we should include the filename and linenumber in the MatchError.

I also used the `LINE_NUMBER_KEY` const var instead of using `"__line__"`.

This is minor and should not impact anyone now, but it makes fixing identified errors easier in #1805 (this was extracted from that PR).