### PR TITLE
Recursively extract tasks from blocks

### DIFF
--- a/test/TestSkipInsideYaml.py
+++ b/test/TestSkipInsideYaml.py
@@ -86,6 +86,7 @@ ROLE_TASKS_WITH_BLOCK_BECOME = '''\
         - name: bar
           become_user: jonhdaa
           command: "/etc/test.sh"
+          changed_when: false
 '''
 
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -156,6 +156,20 @@ def test_extract_from_list() -> None:
         utils.extract_from_list(blocks, ['test_string'])
 
 
+def test_extract_from_list_recursive() -> None:
+    """Check that tasks get extracted from blocks if present."""
+    block = {
+        'block': [{'block': [{'name': 'hello', 'command': 'whoami'}]}],
+    }
+    blocks = [block]
+
+    test_list = utils.extract_from_list(blocks, ['block'])
+    assert list(block['block']) == test_list
+
+    test_list_recursive = utils.extract_from_list(blocks, ['block'], recursive=True)
+    assert block['block'] + block['block'][0]['block'] == test_list_recursive  # type: ignore
+
+
 @pytest.mark.parametrize(
     ('template', 'output'),
     (


### PR DESCRIPTION
allow matchtask() to match embedded tasks

```
- block:
  - block:
    - template:
        src: ...
```

See for example:
https://github.com/ansible-community/ansible-lint/blob/ff90dd4a5b1f105028a4c4d5d70a9cd2bcb69bdb/examples/roles/role_for_no_same_owner/tasks/fail.yml#L13-L19

The `no-same-owner` rule, added in #1450, uses that test tasks file. It does its own task parsing to ensure it can recursively find tasks. We should allow all rules to recursively find tasks.