### PR TITLE
Refactor coverage implementation

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -177,7 +177,7 @@ jobs:
     #       ${{ runner.os }}-
     - name: Install tox
       run: |
-        python3 -m pip install --upgrade tox
+        python3 -m pip install --upgrade tox 'coverage[toml]'
     - name: Log installed dists
       run: >-
         python3 -m pip freeze --all
@@ -211,6 +211,15 @@ jobs:
         python3 -m tox
       env:
         TOXENV: ${{ matrix.tox_env }}-devel
+    - name: Combine coverage data
+      # produce a single .coverage file at repo root
+      run: coverage combine .tox/.coverage.*
+    - name: Upload coverage data
+      uses: codecov/codecov-action@v1
+      with:
+        name: ${{ matrix.tox_env }}
+        fail_ci_if_error: true  # optional (default = false)
+        verbose: true  # optional (default = false)
     - name: Archive logs
       uses: actions/upload-artifact@v2
       with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: true
+comment: false
+coverage:
+  status:
+    patch: false
+    project:
+      threshold: 0.5%

--- a/constraints.txt
+++ b/constraints.txt
@@ -21,7 +21,6 @@ py==1.11.0
 pygments==2.11.2
 pyparsing==3.0.6
 pytest==6.2.5
-pytest-cov==3.0.0
 pytest-forked==1.4.0
 pytest-xdist==2.5.0
 pyyaml==6.0
@@ -30,7 +29,6 @@ ruamel.yaml==0.17.20 ; python_version >= "3.7"
 ruamel.yaml.clib==0.2.6
 tenacity==8.0.1
 toml==0.10.2
-tomli==1.2.1
 wcmatch==8.3
 yamllint==1.26.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,16 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:"
+]
+
 [tool.black]
 skip-string-normalization = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,9 +101,9 @@ core =
 yamllint =
   yamllint >= 1.25.0  # GPLv3
 test =
+  coverage >= 6.2
   flaky >= 3.7.0
   pytest >= 6.0.1
-  pytest-cov >= 2.10.1
   pytest-xdist >= 2.1.0
   psutil  # soft-dep of pytest-xdist
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,17 +27,9 @@ deps =
 commands =
   # safety measure to assure we do not accidentally run tests with broken dependencies
   {envpython} -m pip check
-  # We add coverage options but not making them mandatory as we do not want to force
-  # pytest users to run coverage when they just want to run a single test with `pytest -k test`
-  {envpython} -m pytest \
+  coverage run -m pytest \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
-  {posargs:\
-    -p pytest_cov \
-    --cov ansiblelint \
-    --cov "{envsitepackagesdir}/ansiblelint" \
-    --cov-report term-missing:skip-covered \
-    --cov-report xml:.test-results/pytest/cov.xml \
-    --no-cov-on-fail}
+  {posargs}
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
   FORCE_COLOR


### PR DESCRIPTION
Adopts the same coverage configuration we use on ansible-compat, which includes:

- avoid using pytest-cov
- integration with codecov.io
- avoid noisy messages from codecov on pull requests, as   we have a GHA check to report its status