### PR TITLE
Restore use of pytest-cov

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -21,6 +21,7 @@ py==1.11.0
 pygments==2.11.2
 pyparsing==3.0.6
 pytest==6.2.5
+pytest-cov==3.0.0
 pytest-forked==1.4.0
 pytest-xdist==2.5.0
 pyyaml==6.0
@@ -29,6 +30,7 @@ ruamel.yaml==0.17.20 ; python_version >= "3.7"
 ruamel.yaml.clib==0.2.6
 tenacity==8.0.1
 toml==0.10.2
+tomli==1.2.1
 wcmatch==8.3
 yamllint==1.26.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ test =
   coverage >= 6.2
   flaky >= 3.7.0
   pytest >= 6.0.1
+  pytest-cov >= 2.10.1
   pytest-xdist >= 2.1.0
   psutil  # soft-dep of pytest-xdist
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,16 @@ deps =
 commands =
   # safety measure to assure we do not accidentally run tests with broken dependencies
   {envpython} -m pip check
-  coverage run -m pytest \
+  # We add coverage options but not making them mandatory as we do not want to force
+  # pytest users to run coverage when they just want to run a single test with `pytest -k test`
+  {envpython} -m pytest \
   --junitxml "{toxworkdir}/junit.{envname}.xml" \
-  {posargs}
+  {posargs:\
+    -p pytest_cov \
+    --cov ansiblelint \
+    --cov "{envsitepackagesdir}/ansiblelint" \
+    --cov-report term-missing:skip-covered \
+    --no-cov-on-fail}
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
   FORCE_COLOR


### PR DESCRIPTION
Partial revert of changes made by #1810, basically switches back
to using pytest-cov while keeping codecov settings in place.