### PR TITLE
Allow noqa to be used in more lintable kinds

### DIFF
--- a/src/ansiblelint/skip_utils.py
+++ b/src/ansiblelint/skip_utils.py
@@ -97,7 +97,7 @@ def _append_skipped_rules(
     # parse file text using 2nd parser library
     ruamel_data = load_data(lintable.content)
 
-    if lintable.kind == 'meta':
+    if lintable.kind in ['yaml', 'requirements', 'vars', 'meta', 'reno']:
         pyyaml_data[0]['skipped_rules'] = _get_rule_skips_from_yaml(ruamel_data)
         return pyyaml_data
 
@@ -114,8 +114,6 @@ def _append_skipped_rules(
             # assume it is a playbook, check needs to be added higher in the
             # call stack, and can remove this except
             return pyyaml_data
-    elif lintable.kind in ['yaml', 'requirements', 'vars', 'meta', 'reno']:
-        return pyyaml_data
     else:
         # For unsupported file types, we return empty skip lists
         return None

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -4,7 +4,6 @@ import pytest
 from ansiblelint.skip_utils import get_rule_skips_from_line
 from ansiblelint.testing import RunFromText
 
-
 PLAYBOOK_WITH_NOQA = '''\
 - hosts: all
   vars:

--- a/test/test_skiputils.py
+++ b/test/test_skiputils.py
@@ -2,6 +2,20 @@
 import pytest
 
 from ansiblelint.skip_utils import get_rule_skips_from_line
+from ansiblelint.testing import RunFromText
+
+
+PLAYBOOK_WITH_NOQA = '''\
+- hosts: all
+  vars:
+    SOMEVARNOQA: "Foo"  # noqa var-naming
+    SOMEVAR: "Bar"
+  tasks:
+    - name: "Set the SOMEOTHERVAR"
+      set_fact:
+        SOMEOTHERVARNOQA: "Baz"  # noqa var-naming
+        SOMEOTHERVAR: "Bat"
+'''
 
 
 @pytest.mark.parametrize(
@@ -15,3 +29,9 @@ def test_get_rule_skips_from_line(line: str, expected: str) -> None:
     """Validate get_rule_skips_from_line."""
     x = get_rule_skips_from_line(line)
     assert x == [expected]
+
+
+def test_playbook_noqa(default_text_runner: RunFromText) -> None:
+    """Check that noqa is properly taken into account on vars and tasks."""
+    results = default_text_runner.run_playbook(PLAYBOOK_WITH_NOQA)
+    assert len(results) == 2


### PR DESCRIPTION
Following a discussion in #1723 this is the pull request based on the work of @relrod.

I added a little test for the noqa with the playbook from the issue. I don't really know how to test for the rest of the possible ``lintable.kinds``.