### PR TITLE
Add ability to load .config/ansible-lint.yml

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -10,10 +10,11 @@ Configuring
 Configuration File
 ------------------
 
-Ansible-lint supports local configuration via a ``.ansible-lint`` configuration
-file. Ansible-lint checks the working directory for the presence of this file
-and applies any configuration found there. The configuration file location can
-also be overridden via the ``-c path/to/file`` CLI flag.
+Ansible-lint supports local configuration via a ``.ansible-lint`` or
+``.config/ansible-lint.yml`` configuration files. Ansible-lint checks the
+working directory for the presence of this file and applies any configuration
+found there. The configuration file location can also be overridden via the
+``-c path/to/file`` CLI flag.
 
 When configuration file is not found in current directory, the tool will try
 to look for one in parent directories but it will not go outside current git

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -118,7 +118,7 @@ class App:
                 "configuration file:"
             )
             msg += """\
-# .ansible-lint
+# .config/ansible-lint.yml
 warn_list:  # or 'skip_list' to silence them completely
 """
             msg += "".join(sorted(entries))

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -89,9 +89,12 @@ def load_config(config_file: str) -> Dict[Any, Any]:
     return config
 
 
-def get_config_path(config_file: str = ".ansible-lint") -> Optional[str]:
+def get_config_path(config_file: Optional[str] = None) -> Optional[str]:
     """Return local config file."""
-    project_filenames = [config_file]
+    if config_file:
+        project_filenames = [config_file]
+    else:
+        project_filenames = [".ansible-lint", ".config/ansible-lint.yml"]
     parent = tail = os.getcwd()
     while tail:
         for project_filename in project_filenames:
@@ -268,7 +271,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-c",
         dest="config_file",
-        help="Specify configuration file to use.  " 'Defaults to ".ansible-lint"',
+        help="Specify configuration file to use. By default it will look for '.ansible-lint' or '.config/ansible-lint.yml'",
     )
     parser.add_argument(
         "--offline",

--- a/test/TestExamples.py
+++ b/test/TestExamples.py
@@ -67,6 +67,6 @@ def test_custom_kinds() -> None:
     result = run_ansible_lint("-vv", "--offline", "examples/other/")
     assert result.returncode == 0
     # .yaml-too is not a recognized extension and unless is manually defined
-    # in our .ansible-lint config, the test would not identify it as yaml file.
+    # in our ansible-lint config, the test would not identify it as yaml file.
     assert "Examining examples/other/some.yaml-too of type yaml" in result.stderr
     assert "Examining examples/other/some.j2.yaml of type jinja2" in result.stderr

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -262,7 +262,7 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
         "examples/playbooks/empty_playbook.yml:1: "
         "syntax-check Empty playbook, nothing to do" in out
     )
-    # assures that our .ansible-lint exclude was effective in excluding github files
+    # assures that our ansible-lint config exclude was effective in excluding github files
     assert "Identified: .github/" not in out
     # assures that we can parse playbooks as playbooks
     assert "Identified: test/test/always-run-success.yml" not in err


### PR DESCRIPTION
This will allow users to declutter their project root directory by allowing users to put configuration in `.config/ansible-lint.yml` instead of `.ansible-lint` file.

It matches a feature already implemented by molecule and supported by https://dot-config.github.io -- the goal being to reduce cluttering of root project directories.

This does not change the ability to load the file from its current location.