### PR TITLE
Add utility function to initialize ansible Templar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -330,6 +330,8 @@ linkcheck_workers = 25
 nitpicky = True
 nitpick_ignore = [
     ('py:class', 'ansible.parsing.yaml.objects.AnsibleBaseYAMLObject'),
+    ('py:class', 'ansible.template.Templar'),
+    ('py:class', 'Templar'),
     ('py:class', 'Lintable'),
     ('py:class', 'yaml'),
     ('py:class', 'role'),

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -102,10 +102,8 @@ def path_dwim(basedir: str, given: str) -> str:
     return str(dl.path_dwim(given))
 
 
-def ansible_template(
-    basedir: str, varname: Any, templatevars: Any, **kwargs: Any
-) -> Any:
-    """Render a templated string."""
+def ansible_templar(basedir: str, templatevars: Any) -> Templar:
+    """Create an Ansible Templar using templatevars."""
     # `basedir` is the directory containing the lintable file.
     # Therefore, for tasks in a role, `basedir` has the form
     # `roles/some_role/tasks`. On the other hand, the search path
@@ -117,6 +115,14 @@ def ansible_template(
     dl = DataLoader()
     dl.set_basedir(basedir)
     templar = Templar(dl, variables=templatevars)
+    return templar
+
+
+def ansible_template(
+    basedir: str, varname: Any, templatevars: Any, **kwargs: Any
+) -> Any:
+    """Render a templated string."""
+    templar = ansible_templar(basedir=basedir, templatevars=templatevars)
     return templar.template(varname, **kwargs)
 
 


### PR DESCRIPTION
This commit was cherry-picked from #1805. There are a variety of situations where it is helpful to get a `Templar` instance instead of delegating template parsing. So, this splits the `ansible_template` function into two functions: `ansible_template` (no change in functionality) and `ansible_templar` (the function I need).

PS: I'm @cognifloyd - I'm filing this PR with my work account so github stops complaining when I push commits using that account once this PR is merged.