### PR TITLE
Add utils.nested_items_path and Deprecate utils.nested_items

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -76,8 +76,7 @@ def initialize_logger(level: int = 0) -> None:
     # Unknown logging level is treated as DEBUG
     logging_level = VERBOSITY_MAP.get(level, logging.DEBUG)
     logger.setLevel(logging_level)
-    # Also pass all warnings.warn() messages through the logger
-    logging.captureWarnings(True)
+    logging.captureWarnings(True)  # pass all warnings.warn() messages through logging
     # Use module-level _logger instance to validate it
     _logger.debug("Logging initialized to level %s", logging_level)
 

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -76,6 +76,8 @@ def initialize_logger(level: int = 0) -> None:
     # Unknown logging level is treated as DEBUG
     logging_level = VERBOSITY_MAP.get(level, logging.DEBUG)
     logger.setLevel(logging_level)
+    # Also pass all warnings.warn() messages through the logger
+    logging.captureWarnings(True)
     # Use module-level _logger instance to validate it
     _logger.debug("Logging initialized to level %s", logging_level)
 

--- a/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.testing import RunFromText
-from ansiblelint.utils import nested_items_path
+from ansiblelint.yaml_utils import nested_items_path
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.testing import RunFromText
-from ansiblelint.utils import nested_items
+from ansiblelint.utils import nested_items_path
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -31,7 +31,7 @@ class ComparisonToEmptyStringRule(AnsibleLintRule):
     def matchtask(
         self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
     ) -> Union[bool, str]:
-        for k, v, _ in nested_items(task):
+        for k, v, _ in nested_items_path(task):
             if k == 'when':
                 if isinstance(v, str):
                     if self.empty_string_compare.search(v):

--- a/src/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/src/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import nested_items
+from ansiblelint.utils import nested_items_path
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -29,7 +29,7 @@ class ComparisonToLiteralBoolRule(AnsibleLintRule):
     def matchtask(
         self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
     ) -> Union[bool, str]:
-        for k, v, _ in nested_items(task):
+        for k, v, _ in nested_items_path(task):
             if k == 'when':
                 if isinstance(v, str):
                     if self.literal_bool_compare.search(v):

--- a/src/ansiblelint/rules/ComparisonToLiteralBoolRule.py
+++ b/src/ansiblelint/rules/ComparisonToLiteralBoolRule.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import nested_items_path
+from ansiblelint.yaml_utils import nested_items_path
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/src/ansiblelint/rules/NoTabsRule.py
+++ b/src/ansiblelint/rules/NoTabsRule.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import nested_items_path
+from ansiblelint.yaml_utils import nested_items_path
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/src/ansiblelint/rules/NoTabsRule.py
+++ b/src/ansiblelint/rules/NoTabsRule.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import nested_items
+from ansiblelint.utils import nested_items_path
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -29,10 +29,15 @@ class NoTabsRule(AnsibleLintRule):
     def matchtask(
         self, task: Dict[str, Any], file: 'Optional[Lintable]' = None
     ) -> Union[bool, str]:
-        for k, v, parent in nested_items(task):
+        for k, v, parent_path in nested_items_path(task):
             if isinstance(k, str) and '\t' in k:
                 return True
-            if (parent, k) not in self.allow_list and isinstance(v, str) and '\t' in v:
+            if (
+                parent_path
+                and (parent_path[-1], k) not in self.allow_list
+                and isinstance(v, str)
+                and '\t' in v
+            ):
                 return True
         return False
 

--- a/src/ansiblelint/rules/NoTabsRule.py
+++ b/src/ansiblelint/rules/NoTabsRule.py
@@ -32,9 +32,9 @@ class NoTabsRule(AnsibleLintRule):
         for k, v, parent_path in nested_items_path(task):
             if isinstance(k, str) and '\t' in k:
                 return True
+            parent_key = "" if not parent_path else parent_path[-1]
             if (
-                parent_path
-                and (parent_path[-1], k) not in self.allow_list
+                (parent_key, k) not in self.allow_list
                 and isinstance(v, str)
                 and '\t' in v
             ):

--- a/src/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/src/ansiblelint/rules/VariableHasSpacesRule.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import nested_items
+from ansiblelint.utils import nested_items_path
 
 
 class VariableHasSpacesRule(AnsibleLintRule):
@@ -25,7 +25,7 @@ class VariableHasSpacesRule(AnsibleLintRule):
     def matchtask(
         self, task: Dict[str, Any], file: Optional[Lintable] = None
     ) -> Union[bool, str]:
-        for k, v, _ in nested_items(task):
+        for k, v, _ in nested_items_path(task):
             if isinstance(v, str):
                 cleaned = self.exclude_json_re.sub("", v)
                 if bool(self.bracket_regex.search(cleaned)):

--- a/src/ansiblelint/rules/VariableHasSpacesRule.py
+++ b/src/ansiblelint/rules/VariableHasSpacesRule.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.utils import nested_items_path
+from ansiblelint.yaml_utils import nested_items_path
 
 
 class VariableHasSpacesRule(AnsibleLintRule):

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -27,17 +27,7 @@ from argparse import Namespace
 from collections.abc import ItemsView
 from functools import lru_cache
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 import yaml
 from ansible import constants
@@ -889,7 +879,7 @@ def convert_to_boolean(value: Any) -> bool:
 
 def nested_items(
     data: Union[Dict[Any, Any], List[Any]], parent: str = ""
-) -> Generator[Tuple[Any, Any, str], None, None]:
+) -> Iterator[Tuple[Any, Any, str]]:
     """Iterate a nested data structure."""
     if isinstance(data, dict):
         for k, v in data.items():
@@ -906,7 +896,7 @@ def nested_items(
 def nested_items_path(
     data: Union[Dict[Any, Any], List[Any]],
     parent_path: Optional[List[Union[str, int]]] = None,
-) -> Generator[Tuple[Any, Any, List[Union[str, int]]], None, None]:
+) -> Iterator[Tuple[Any, Any, List[Union[str, int]]]]:
     """Iterate a nested data structure."""
     if parent_path is None:
         parent_path = []

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -33,13 +33,11 @@ from typing import (
     Callable,
     Dict,
     Generator,
-    Iterator,
     List,
     Optional,
     Sequence,
     Tuple,
     Union,
-    cast,
 )
 
 import yaml
@@ -896,7 +894,7 @@ def nested_items(
     """Iterate a nested data structure."""
     warnings.warn(
         "Call to deprecated function ansiblelint.utils.nested_items. "
-        "Use ansiblelint.utils.nested_items_path instead.",
+        "Use ansiblelint.yaml_utils.nested_items_path instead.",
         category=DeprecationWarning,
         stacklevel=2,
     )
@@ -910,85 +908,3 @@ def nested_items(
             yield "list-item", item, parent
             for k, v, p in nested_items(item):
                 yield k, v, p
-
-
-def nested_items_path(
-    data: Union[Dict[Any, Any], List[Any]],
-    parent_path: Optional[List[Union[str, int]]] = None,
-) -> Iterator[Tuple[Any, Any, List[Union[str, int]]]]:
-    """Iterate a nested data structure, yielding key/index, value, and parent_path.
-
-    This is a recursive function that calls itself for each nested layer of data.
-    Each iteration yields:
-
-    1. the current item's dictionary key or list index,
-    2. the current item's value, and
-    3. the path to the current item from the outermost data structure.
-
-    For dicts, the yielded (1) key and (2) value are what ``dict.items()`` yields.
-    For lists, the yielded (1) index and (2) value are what ``enumerate()`` yields.
-    The final component, the parent path, is a list of dict keys and list indexes.
-    The parent path can be helpful in providing error messages that indicate
-    precisely which part of a yaml file (or other data structure) needs to be fixed.
-
-    For example, given this playbook:
-
-    .. code-block:: yaml
-
-        - name: a play
-          tasks:
-          - name: a task
-            debug:
-              msg: foobar
-
-    Here's the first and last yielded items:
-
-    .. code-block:: python
-
-        >>> playbook=[{"name": "a play", "tasks": [{"name": "a task", "debug": {"msg": "foobar"}}]}]
-        >>> next( nested_items_path( playbook ) )
-        (0, {'name': 'a play', 'tasks': [{'name': 'a task', 'debug': {'msg': 'foobar'}}]}, [])
-        >>> list( nested_items_path( playbook ) )[-1]
-        ('msg', 'foobar', [0, 'tasks', 0, 'debug'])
-
-    Note that, for outermost data structure, the parent path is ``[]`` because
-    you do not need to descend into any nested dicts or lists to find the indicated
-    key and value.
-
-    If a rule were designed to prohibit "foobar" debug messages, it could use the
-    parent path to provide a path to the problematic ``msg``. It might use a jq-style
-    path in its error message: "the error is at ``.[0].tasks[0].debug.msg``".
-    Or if a utility could automatically fix issues, it could use the path to descend
-    to the parent object using something like this:
-
-    .. code-block:: python
-
-        target = data
-        for segment in parent_path:
-            target = target[segment]
-
-    :param data: The nested data (dicts or lists).
-    :param parent_path: Do not use this param. It is used internally to recursively
-                        build the yielded parent path (list of keys, indexes).
-
-    :returns: each iteration yields the key (of the parent dict) or the index (lists)
-    """
-    if parent_path is None:
-        parent_path = []
-    convert_to_tuples_type = Callable[
-        [Union[Dict[Any, Any], List[Any]]],
-        Iterator[Tuple[Union[str, int], Any]],
-    ]
-    if isinstance(data, dict):
-        # dict subclasses can override items() so don't use dict.items directly
-        convert_to_tuples = cast(convert_to_tuples_type, data.__class__.items)
-    elif isinstance(data, list):
-        convert_to_tuples = cast(convert_to_tuples_type, enumerate)
-    else:
-        raise TypeError(
-            f"Expected a dict or a list but got {data!r} of type '{type(data)}'",
-        )
-    for key, value in convert_to_tuples(data):
-        yield key, value, parent_path
-        if isinstance(value, (dict, list)):
-            yield from nested_items_path(data=value, parent_path=parent_path + [key])

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -955,7 +955,7 @@ def nested_items_path(
     you do not need to descend into any nested dicts or lists to find the indicated
     key and value.
 
-    If a rule were designed to prohimit "foobar" debug messages, it could use the
+    If a rule were designed to prohibit "foobar" debug messages, it could use the
     parent path to provide a path to the problematic ``msg``. It might use a jq-style
     path in its error message: "the error is at ``.[0].tasks[0].debug.msg``".
     Or if a utility could automatically fix issues, it could use the path to descend

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -905,7 +905,7 @@ def nested_items(
 
 def nested_items_path(
     data: Union[Dict[Any, Any], List[Any]],
-    parent_path: Optional[List[Union[str, int]]] = None
+    parent_path: Optional[List[Union[str, int]]] = None,
 ) -> Generator[Tuple[Any, Any, List[Union[str, int]]], None, None]:
     """Iterate a nested data structure."""
     if parent_path is None:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -975,10 +975,14 @@ def nested_items_path(
     if parent_path is None:
         parent_path = []
     if isinstance(data, dict):
-        for key, value in data.items():
-            yield key, value, parent_path
+        convert_to_tuples = data.__class__.items  # dict subclasses can override items
+    elif isinstance(data, list):
+        convert_to_tuples = enumerate
+    else:
+        raise TypeError(
+            f"nested_items_path expects a dict or a list but got {type(data)}"
+        )
+    for key, value in convert_to_tuples(data):
+        yield key, value, parent_path
+        if isinstance(value, (dict, list)):
             yield from nested_items_path(value, parent_path + [key])
-    if isinstance(data, list):
-        for index, item in enumerate(data):
-            yield index, item, parent_path
-            yield from nested_items_path(item, parent_path + [index])

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -985,4 +985,4 @@ def nested_items_path(
     for key, value in convert_to_tuples(data):
         yield key, value, parent_path
         if isinstance(value, (dict, list)):
-            yield from nested_items_path(value, parent_path + [key])
+            yield from nested_items_path(data=value, parent_path=parent_path + [key])

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -23,6 +23,7 @@ import contextlib
 import inspect
 import logging
 import os
+import warnings
 from argparse import Namespace
 from collections.abc import ItemsView
 from functools import lru_cache
@@ -877,11 +878,16 @@ def convert_to_boolean(value: Any) -> bool:
     return bool(boolean(value))
 
 
-# TODO: mark this function deprecated. Use nested_items_path instead.
 def nested_items(
     data: Union[Dict[Any, Any], List[Any]], parent: str = ""
 ) -> Iterator[Tuple[Any, Any, str]]:
     """Iterate a nested data structure."""
+    warnings.warn(
+        "Call to deprecated function ansiblelint.utils.nested_items. "
+        "Use ansiblelint.utils.nested_items_path instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     if isinstance(data, dict):
         for k, v in data.items():
             yield k, v, parent

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -28,7 +28,18 @@ from argparse import Namespace
 from collections.abc import ItemsView
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import yaml
 from ansible import constants
@@ -880,7 +891,7 @@ def convert_to_boolean(value: Any) -> bool:
 
 def nested_items(
     data: Union[Dict[Any, Any], List[Any]], parent: str = ""
-) -> Iterator[Tuple[Any, Any, str]]:
+) -> Generator[Tuple[Any, Any, str], None, None]:
     """Iterate a nested data structure."""
     warnings.warn(
         "Call to deprecated function ansiblelint.utils.nested_items. "

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -877,6 +877,7 @@ def convert_to_boolean(value: Any) -> bool:
     return bool(boolean(value))
 
 
+# TODO: mark this function deprecated. Use nested_items_path instead.
 def nested_items(
     data: Union[Dict[Any, Any], List[Any]], parent: str = ""
 ) -> Iterator[Tuple[Any, Any, str]]:

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -901,3 +901,22 @@ def nested_items(
             yield "list-item", item, parent
             for k, v, p in nested_items(item):
                 yield k, v, p
+
+
+def nested_items_path(
+    data: Union[Dict[Any, Any], List[Any]],
+    parent_path: Optional[List[Union[str, int]]] = None
+) -> Generator[Tuple[Any, Any, List[Union[str, int]]], None, None]:
+    """Iterate a nested data structure."""
+    if parent_path is None:
+        parent_path = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            yield key, value, parent_path
+            for k, v, p in nested_items_path(value, parent_path + [key]):
+                yield k, v, p
+    if isinstance(data, list):
+        for index, item in enumerate(data):
+            yield index, item, parent_path
+            for k, v, p in nested_items_path(item, parent_path + [index]):
+                yield k, v, p

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -986,7 +986,7 @@ def nested_items_path(
         convert_to_tuples = cast(convert_to_tuples_type, enumerate)
     else:
         raise TypeError(
-            f"nested_items_path expects a dict or a list but got {type(data)}"
+            f"Expected a dict or a list but got {data!r} of type '{type(data)}'",
         )
     for key, value in convert_to_tuples(data):
         yield key, value, parent_path

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -910,10 +910,8 @@ def nested_items_path(
     if isinstance(data, dict):
         for key, value in data.items():
             yield key, value, parent_path
-            for k, v, p in nested_items_path(value, parent_path + [key]):
-                yield k, v, p
+            yield from nested_items_path(value, parent_path + [key])
     if isinstance(data, list):
         for index, item in enumerate(data):
             yield index, item, parent_path
-            for k, v, p in nested_items_path(item, parent_path + [index]):
-                yield k, v, p
+            yield from nested_items_path(item, parent_path + [index])

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -925,8 +925,8 @@ def nested_items_path(
     2. the current item's value, and
     3. the path to the current item from the outermost data structure.
 
-    For dicts, the yielded (1) key and (2) value are what mydict.items() yields.
-    For lists, the yielded (1) index and (2) value are what enumerate(mylist) yields.
+    For dicts, the yielded (1) key and (2) value are what ``dict.items()`` yields.
+    For lists, the yielded (1) index and (2) value are what ``enumerate()`` yields.
     The final component, the parent path, is a list of dict keys and list indexes.
     The parent path can be helpful in providing error messages that indicate
     precisely which part of a yaml file (or other data structure) needs to be fixed.

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -39,6 +39,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 
 import yaml
@@ -974,10 +975,15 @@ def nested_items_path(
     """
     if parent_path is None:
         parent_path = []
+    convert_to_tuples_type = Callable[
+        [Union[Dict[Any, Any], List[Any]]],
+        Iterator[Tuple[Union[str, int], Any]],
+    ]
     if isinstance(data, dict):
-        convert_to_tuples = data.__class__.items  # dict subclasses can override items
+        # dict subclasses can override items() so don't use dict.items directly
+        convert_to_tuples = cast(convert_to_tuples_type, data.__class__.items)
     elif isinstance(data, list):
-        convert_to_tuples = enumerate
+        convert_to_tuples = cast(convert_to_tuples_type, enumerate)
     else:
         raise TypeError(
             f"nested_items_path expects a dict or a list but got {type(data)}"

--- a/src/ansiblelint/utils.py
+++ b/src/ansiblelint/utils.py
@@ -928,7 +928,7 @@ def nested_items_path(
     For lists, the yielded (1) index and (2) value are what enumerate(mylist) yields.
     The final component, the parent path, is a list of dict keys and list indexes.
     The parent path can be helpful in providing error messages that indicate
-    precisely which part of a yaml file (or other data strucutre) needs to be fixed.
+    precisely which part of a yaml file (or other data structure) needs to be fixed.
 
     For example, given this playbook:
 

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, 
 
 
 def nested_items_path(
-    data: Union[Dict[Any, Any], List[Any]],
+    collection: Union[Dict[Any, Any], List[Any]],
     parent_path: Optional[List[Union[str, int]]] = None,
 ) -> Iterator[Tuple[Any, Any, List[Union[str, int]]]]:
     """Iterate a nested data structure, yielding key/index, value, and parent_path.
@@ -57,7 +57,7 @@ def nested_items_path(
         for segment in parent_path:
             target = target[segment]
 
-    :param data: The nested data (dicts or lists).
+    :param collection: The nested data (dicts or lists).
     :param parent_path: Do not use this param. It is used internally to recursively
                         build the yielded parent path (list of keys, indexes).
 
@@ -69,16 +69,19 @@ def nested_items_path(
         [Union[Dict[Any, Any], List[Any]]],
         Iterator[Tuple[Union[str, int], Any]],
     ]
-    if isinstance(data, dict):
+    if isinstance(collection, dict):
         # dict subclasses can override items() so don't use dict.items directly
-        convert_to_tuples = cast(convert_to_tuples_type, data.__class__.items)
-    elif isinstance(data, list):
+        convert_to_tuples = cast(convert_to_tuples_type, collection.__class__.items)
+    elif isinstance(collection, list):
         convert_to_tuples = cast(convert_to_tuples_type, enumerate)
     else:
         raise TypeError(
-            f"Expected a dict or a list but got {data!r} of type '{type(data)}'"
+            f"Expected a dict or a list but got {collection!r} "
+            f"of type '{type(collection)}'"
         )
-    for key, value in convert_to_tuples(data):
+    for key, value in convert_to_tuples(collection):
         yield key, value, parent_path
         if isinstance(value, (dict, list)):
-            yield from nested_items_path(data=value, parent_path=parent_path + [key])
+            yield from nested_items_path(
+                collection=value, parent_path=parent_path + [key]
+            )

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -1,4 +1,5 @@
 """Utility helpers to simplify working with yaml-based data."""
+import functools
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union, cast
 
 
@@ -73,17 +74,20 @@ def _nested_items_path(
     not be using the parent_path param which is used in recursive _nested_items_path
     calls to build up the path to the parent object of the current key/index, value.
     """
+    # we have to cast each convert_to_tuples assignment or mypy complains
+    # that both assignments (for dict and list) do not have the same type
     convert_to_tuples_type = Callable[
         [Union[Dict[Any, Any], List[Any]]],
         Iterator[Tuple[Union[str, int], Any]],
     ]
     if isinstance(data_collection, dict):
-        # dict subclasses can override items() so don't use dict.items directly
         convert_to_tuples = cast(
-            convert_to_tuples_type, data_collection.__class__.items
+            convert_to_tuples_type, functools.partial(data_collection.items)
         )
     elif isinstance(data_collection, list):
-        convert_to_tuples = cast(convert_to_tuples_type, enumerate)
+        convert_to_tuples = cast(
+            convert_to_tuples_type, functools.partial(enumerate, data_collection)
+        )
     else:
         raise TypeError(
             f"Expected a dict or a list but got {data_collection!r} "

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -1,0 +1,84 @@
+"""Utility helpers to simplify working with yaml-based data."""
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, cast
+
+
+def nested_items_path(
+    data: Union[Dict[Any, Any], List[Any]],
+    parent_path: Optional[List[Union[str, int]]] = None,
+) -> Iterator[Tuple[Any, Any, List[Union[str, int]]]]:
+    """Iterate a nested data structure, yielding key/index, value, and parent_path.
+
+    This is a recursive function that calls itself for each nested layer of data.
+    Each iteration yields:
+
+    1. the current item's dictionary key or list index,
+    2. the current item's value, and
+    3. the path to the current item from the outermost data structure.
+
+    For dicts, the yielded (1) key and (2) value are what ``dict.items()`` yields.
+    For lists, the yielded (1) index and (2) value are what ``enumerate()`` yields.
+    The final component, the parent path, is a list of dict keys and list indexes.
+    The parent path can be helpful in providing error messages that indicate
+    precisely which part of a yaml file (or other data structure) needs to be fixed.
+
+    For example, given this playbook:
+
+    .. code-block:: yaml
+
+        - name: a play
+          tasks:
+          - name: a task
+            debug:
+              msg: foobar
+
+    Here's the first and last yielded items:
+
+    .. code-block:: python
+
+        >>> playbook=[{"name": "a play", "tasks": [{"name": "a task", "debug": {"msg": "foobar"}}]}]
+        >>> next( nested_items_path( playbook ) )
+        (0, {'name': 'a play', 'tasks': [{'name': 'a task', 'debug': {'msg': 'foobar'}}]}, [])
+        >>> list( nested_items_path( playbook ) )[-1]
+        ('msg', 'foobar', [0, 'tasks', 0, 'debug'])
+
+    Note that, for outermost data structure, the parent path is ``[]`` because
+    you do not need to descend into any nested dicts or lists to find the indicated
+    key and value.
+
+    If a rule were designed to prohibit "foobar" debug messages, it could use the
+    parent path to provide a path to the problematic ``msg``. It might use a jq-style
+    path in its error message: "the error is at ``.[0].tasks[0].debug.msg``".
+    Or if a utility could automatically fix issues, it could use the path to descend
+    to the parent object using something like this:
+
+    .. code-block:: python
+
+        target = data
+        for segment in parent_path:
+            target = target[segment]
+
+    :param data: The nested data (dicts or lists).
+    :param parent_path: Do not use this param. It is used internally to recursively
+                        build the yielded parent path (list of keys, indexes).
+
+    :returns: each iteration yields the key (of the parent dict) or the index (lists)
+    """
+    if parent_path is None:
+        parent_path = []
+    convert_to_tuples_type = Callable[
+        [Union[Dict[Any, Any], List[Any]]],
+        Iterator[Tuple[Union[str, int], Any]],
+    ]
+    if isinstance(data, dict):
+        # dict subclasses can override items() so don't use dict.items directly
+        convert_to_tuples = cast(convert_to_tuples_type, data.__class__.items)
+    elif isinstance(data, list):
+        convert_to_tuples = cast(convert_to_tuples_type, enumerate)
+    else:
+        raise TypeError(
+            f"Expected a dict or a list but got {data!r} of type '{type(data)}'"
+        )
+    for key, value in convert_to_tuples(data):
+        yield key, value, parent_path
+        if isinstance(value, (dict, list)):
+            yield from nested_items_path(data=value, parent_path=parent_path + [key])

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -76,16 +76,13 @@ def _nested_items_path(
     """
     # we have to cast each convert_to_tuples assignment or mypy complains
     # that both assignments (for dict and list) do not have the same type
-    convert_to_tuples_type = Callable[
-        [Union[Dict[Any, Any], List[Any]]],
-        Iterator[Tuple[Union[str, int], Any]],
-    ]
+    convert_to_tuples_type = Callable[[], Iterator[Tuple[Union[str, int], Any]]]
     if isinstance(data_collection, dict):
-        convert_to_tuples = cast(
+        convert_data_collection_to_tuples = cast(
             convert_to_tuples_type, functools.partial(data_collection.items)
         )
     elif isinstance(data_collection, list):
-        convert_to_tuples = cast(
+        convert_data_collection_to_tuples = cast(
             convert_to_tuples_type, functools.partial(enumerate, data_collection)
         )
     else:
@@ -93,7 +90,7 @@ def _nested_items_path(
             f"Expected a dict or a list but got {data_collection!r} "
             f"of type '{type(data_collection)}'"
         )
-    for key, value in convert_to_tuples(data_collection):
+    for key, value in convert_data_collection_to_tuples():
         yield key, value, parent_path
         if isinstance(value, (dict, list)):
             yield from _nested_items_path(

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, 
 
 
 def nested_items_path(
-    collection: Union[Dict[Any, Any], List[Any]],
+    data_collection: Union[Dict[Any, Any], List[Any]],
     parent_path: Optional[List[Union[str, int]]] = None,
 ) -> Iterator[Tuple[Any, Any, List[Union[str, int]]]]:
     """Iterate a nested data structure, yielding key/index, value, and parent_path.
@@ -57,7 +57,7 @@ def nested_items_path(
         for segment in parent_path:
             target = target[segment]
 
-    :param collection: The nested data (dicts or lists).
+    :param data_collection: The nested data (dicts or lists).
     :param parent_path: Do not use this param. It is used internally to recursively
                         build the yielded parent path (list of keys, indexes).
 
@@ -69,19 +69,21 @@ def nested_items_path(
         [Union[Dict[Any, Any], List[Any]]],
         Iterator[Tuple[Union[str, int], Any]],
     ]
-    if isinstance(collection, dict):
+    if isinstance(data_collection, dict):
         # dict subclasses can override items() so don't use dict.items directly
-        convert_to_tuples = cast(convert_to_tuples_type, collection.__class__.items)
-    elif isinstance(collection, list):
+        convert_to_tuples = cast(
+            convert_to_tuples_type, data_collection.__class__.items
+        )
+    elif isinstance(data_collection, list):
         convert_to_tuples = cast(convert_to_tuples_type, enumerate)
     else:
         raise TypeError(
-            f"Expected a dict or a list but got {collection!r} "
-            f"of type '{type(collection)}'"
+            f"Expected a dict or a list but got {data_collection!r} "
+            f"of type '{type(data_collection)}'"
         )
-    for key, value in convert_to_tuples(collection):
+    for key, value in convert_to_tuples(data_collection):
         yield key, value, parent_path
         if isinstance(value, (dict, list)):
             yield from nested_items_path(
-                collection=value, parent_path=parent_path + [key]
+                data_collection=value, parent_path=parent_path + [key]
             )

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -526,7 +526,9 @@ def test_nested_items() -> None:
         ("list-item", "apple", "fruits"),
         ("list-item", "orange", "fruits"),
     ]
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(
+        match=r"Call to deprecated function ansiblelint\.utils\.nested_items.*"
+    ):
         assert list(utils.nested_items(data)) == items
 
 

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -526,7 +526,8 @@ def test_nested_items() -> None:
         ("list-item", "apple", "fruits"),
         ("list-item", "orange", "fruits"),
     ]
-    assert list(utils.nested_items(data)) == items
+    with pytest.deprecated_call():
+        assert list(utils.nested_items(data)) == items
 
 
 def test_nested_items_path() -> None:

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -529,6 +529,32 @@ def test_nested_items() -> None:
     assert list(utils.nested_items(data)) == items
 
 
+def test_nested_items_path() -> None:
+    """Verify correct function of nested_items_path()."""
+    data = {
+        "foo": "text",
+        "bar": {"some": "text2"},
+        "fruits": ["apple", "orange"],
+        "answer": [{"forty-two": ["life", "universe", "everything"]}],
+    }
+
+    items = [
+        ("foo", "text", []),
+        ("bar", {"some": "text2"}, []),
+        ("some", "text2", ["bar"]),
+        ("fruits", ["apple", "orange"], []),
+        (0, "apple", ["fruits"]),
+        (1, "orange", ["fruits"]),
+        ("answer", [{"forty-two": ["life", "universe", "everything"]}], []),
+        (0, {"forty-two": ["life", "universe", "everything"]}, ["answer"]),
+        ("forty-two", ["life", "universe", "everything"], ["answer", 0]),
+        (0, "life", ["answer", 0, "forty-two"]),
+        (1, "universe", ["answer", 0, "forty-two"]),
+        (2, "everything", ["answer", 0, "forty-two"]),
+    ]
+    assert list(utils.nested_items_path(data)) == items
+
+
 def test_guess_project_dir(tmp_path: Path) -> None:
     """Verify guess_project_dir()."""
     with cwd(str(tmp_path)):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -559,11 +559,12 @@ def test_nested_items_path() -> None:
 
 
 def test_nested_items_path_raises_typeerror() -> None:
+    """Verify non-dict/non-list types make nested_items_path() raises TypeError."""
     unexpected_data_types = ["string", 42, 1.234, None, ("tuple",), {"set"}]
 
     for data in unexpected_data_types:
         with pytest.raises(TypeError):
-            list(utils.nested_items_path(data))
+            list(utils.nested_items_path(data))  # type: ignore
 
 
 def test_guess_project_dir(tmp_path: Path) -> None:

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Tests for generic utilitary functions."""
+"""Tests for generic utility functions."""
 
 import logging
 import os
@@ -530,41 +530,6 @@ def test_nested_items() -> None:
         match=r"Call to deprecated function ansiblelint\.utils\.nested_items.*"
     ):
         assert list(utils.nested_items(data)) == items
-
-
-def test_nested_items_path() -> None:
-    """Verify correct function of nested_items_path()."""
-    data = {
-        "foo": "text",
-        "bar": {"some": "text2"},
-        "fruits": ["apple", "orange"],
-        "answer": [{"forty-two": ["life", "universe", "everything"]}],
-    }
-
-    items = [
-        ("foo", "text", []),
-        ("bar", {"some": "text2"}, []),
-        ("some", "text2", ["bar"]),
-        ("fruits", ["apple", "orange"], []),
-        (0, "apple", ["fruits"]),
-        (1, "orange", ["fruits"]),
-        ("answer", [{"forty-two": ["life", "universe", "everything"]}], []),
-        (0, {"forty-two": ["life", "universe", "everything"]}, ["answer"]),
-        ("forty-two", ["life", "universe", "everything"], ["answer", 0]),
-        (0, "life", ["answer", 0, "forty-two"]),
-        (1, "universe", ["answer", 0, "forty-two"]),
-        (2, "everything", ["answer", 0, "forty-two"]),
-    ]
-    assert list(utils.nested_items_path(data)) == items
-
-
-def test_nested_items_path_raises_typeerror() -> None:
-    """Verify non-dict/non-list types make nested_items_path() raises TypeError."""
-    unexpected_data_types = ["string", 42, 1.234, None, ("tuple",), {"set"}]
-
-    for data in unexpected_data_types:
-        with pytest.raises(TypeError):
-            list(utils.nested_items_path(data))  # type: ignore
 
 
 def test_guess_project_dir(tmp_path: Path) -> None:

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -558,6 +558,14 @@ def test_nested_items_path() -> None:
     assert list(utils.nested_items_path(data)) == items
 
 
+def test_nested_items_path_raises_typeerror() -> None:
+    unexpected_data_types = ["string", 42, 1.234, None, ("tuple",), {"set"}]
+
+    for data in unexpected_data_types:
+        with pytest.raises(TypeError):
+            list(utils.nested_items_path(data))
+
+
 def test_guess_project_dir(tmp_path: Path) -> None:
     """Verify guess_project_dir()."""
     with cwd(str(tmp_path)):

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -1,0 +1,39 @@
+"""Tests for yaml-related utility functions."""
+import pytest
+
+import ansiblelint.yaml_utils
+
+
+def test_nested_items_path() -> None:
+    """Verify correct function of nested_items_path()."""
+    data = {
+        "foo": "text",
+        "bar": {"some": "text2"},
+        "fruits": ["apple", "orange"],
+        "answer": [{"forty-two": ["life", "universe", "everything"]}],
+    }
+
+    items = [
+        ("foo", "text", []),
+        ("bar", {"some": "text2"}, []),
+        ("some", "text2", ["bar"]),
+        ("fruits", ["apple", "orange"], []),
+        (0, "apple", ["fruits"]),
+        (1, "orange", ["fruits"]),
+        ("answer", [{"forty-two": ["life", "universe", "everything"]}], []),
+        (0, {"forty-two": ["life", "universe", "everything"]}, ["answer"]),
+        ("forty-two", ["life", "universe", "everything"], ["answer", 0]),
+        (0, "life", ["answer", 0, "forty-two"]),
+        (1, "universe", ["answer", 0, "forty-two"]),
+        (2, "everything", ["answer", 0, "forty-two"]),
+    ]
+    assert list(ansiblelint.yaml_utils.nested_items_path(data)) == items
+
+
+def test_nested_items_path_raises_typeerror() -> None:
+    """Verify non-dict/non-list types make nested_items_path() raises TypeError."""
+    unexpected_data_types = ["string", 42, 1.234, None, ("tuple",), {"set"}]
+
+    for data in unexpected_data_types:
+        with pytest.raises(TypeError):
+            list(ansiblelint.yaml_utils.nested_items_path(data))  # type: ignore

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -45,5 +45,5 @@ def test_nested_items_path() -> None:
 )
 def test_nested_items_path_raises_typeerror(invalid_data_input: Any) -> None:
     """Verify non-dict/non-list types make nested_items_path() raises TypeError."""
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Expected a dict or a list.*"):
         list(ansiblelint.yaml_utils.nested_items_path(invalid_data_input))

--- a/test/test_yaml_utils.py
+++ b/test/test_yaml_utils.py
@@ -1,4 +1,6 @@
 """Tests for yaml-related utility functions."""
+from typing import Any
+
 import pytest
 
 import ansiblelint.yaml_utils
@@ -30,10 +32,18 @@ def test_nested_items_path() -> None:
     assert list(ansiblelint.yaml_utils.nested_items_path(data)) == items
 
 
-def test_nested_items_path_raises_typeerror() -> None:
+@pytest.mark.parametrize(
+    'invalid_data_input',
+    (
+        "string",
+        42,
+        1.234,
+        None,
+        ("tuple",),
+        {"set"},
+    ),
+)
+def test_nested_items_path_raises_typeerror(invalid_data_input: Any) -> None:
     """Verify non-dict/non-list types make nested_items_path() raises TypeError."""
-    unexpected_data_types = ["string", 42, 1.234, None, ("tuple",), {"set"}]
-
-    for data in unexpected_data_types:
-        with pytest.raises(TypeError):
-            list(ansiblelint.yaml_utils.nested_items_path(data))  # type: ignore
+    with pytest.raises(TypeError):
+        list(ansiblelint.yaml_utils.nested_items_path(invalid_data_input))


### PR DESCRIPTION
This was extracted from #1805.

There are a lot of cases where I need to not only iterate over the contents of nested dicts/lists, but I also need the path to each item's parent.
For example, this would allow for more descriptive error messages about the location of rule matches and it facilitates the transforms in #1805.

- Add new util function nested_items_path
- Reformat with black
- Add more typehints to satisfy mypy
- convert all uses of nested_items() to nested_items_path()
- add test for nested_items_path utility
- add TODO about marking utils.nested_items deprecated
- Mark utils.nested_items deprecated
