### PR TITLE
Extract list logic to reduce complexity of __main__.main()

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -50,6 +50,8 @@ from ansiblelint.skip_utils import normalize_tag
 from ansiblelint.version import __version__
 
 if TYPE_CHECKING:
+    # RulesCollection must be imported lazily or ansible gets imported too early.
+    from ansiblelint.rules import RulesCollection
     from ansiblelint.runner import LintResult
 
 
@@ -192,6 +194,30 @@ warn_list:  # or 'skip_list' to silence them completely
     return 2
 
 
+def _do_list(rules: "RulesCollection") -> int:
+    # On purpose lazy-imports to avoid pre-loading Ansible
+    # pylint: disable=import-outside-toplevel
+    from ansiblelint.generate_docs import rules_as_rich, rules_as_rst, rules_as_str
+
+    if options.listrules:
+
+        _rule_format_map: Dict[str, Callable[..., Any]] = {
+            'plain': rules_as_str,
+            'rich': rules_as_rich,
+            'rst': rules_as_rst,
+        }
+
+        console.print(_rule_format_map[options.format](rules), highlight=False)
+        return 0
+
+    if options.listtags:
+        console.print(render_yaml(rules.listtags()))
+        return 0
+
+    # we should not get here!
+    return 1
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     """Linter CLI entry point."""
     if argv is None:
@@ -212,25 +238,12 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # On purpose lazy-imports to avoid pre-loading Ansible
     # pylint: disable=import-outside-toplevel
-    from ansiblelint.generate_docs import rules_as_rich, rules_as_rst, rules_as_str
     from ansiblelint.rules import RulesCollection
 
     rules = RulesCollection(options.rulesdirs)
 
-    if options.listrules:
-
-        _rule_format_map: Dict[str, Callable[..., Any]] = {
-            'plain': rules_as_str,
-            'rich': rules_as_rich,
-            'rst': rules_as_rst,
-        }
-
-        console.print(_rule_format_map[options.format](rules), highlight=False)
-        return 0
-
-    if options.listtags:
-        console.print(render_yaml(rules.listtags()))
-        return 0
+    if options.listrules or options.listtags:
+        return _do_list(rules)
 
     if isinstance(options.tags, str):
         options.tags = options.tags.split(',')


### PR DESCRIPTION
Extracted from #1805

When we start adding the fmt options, `main()` becomes too complex so linters start yelling.
This extracts the list specific options to lower that complexity.
