### PR TITLE
Move ansiblelint.testing.RunFromText import into test code

### DIFF
--- a/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
+++ b/src/ansiblelint/rules/ComparisonToEmptyStringRule.py
@@ -6,7 +6,6 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.testing import RunFromText
 from ansiblelint.yaml_utils import nested_items_path
 
 if TYPE_CHECKING:
@@ -52,6 +51,8 @@ class ComparisonToEmptyStringRule(AnsibleLintRule):
 if "pytest" in sys.modules:
 
     import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
     SUCCESS_PLAY = '''
 - hosts: all

--- a/src/ansiblelint/rules/FQCNBuiltinsRule.py
+++ b/src/ansiblelint/rules/FQCNBuiltinsRule.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional, Union
 
 from ansiblelint.file_utils import Lintable
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.testing import RunFromText
 
 builtins = [
     "add_host",
@@ -97,6 +96,8 @@ class FQCNBuiltinsRule(AnsibleLintRule):
 if "pytest" in sys.modules:
 
     import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
     SUCCESS_PLAY = '''
 - hosts: localhost

--- a/src/ansiblelint/rules/IgnoreErrorsRule.py
+++ b/src/ansiblelint/rules/IgnoreErrorsRule.py
@@ -3,7 +3,6 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.testing import RunFromText
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -43,6 +42,8 @@ class IgnoreErrorsRule(AnsibleLintRule):
 
 if "pytest" in sys.modules:
     import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
     IGNORE_ERRORS_TRUE = '''
 - hosts: all

--- a/src/ansiblelint/rules/MissingFilePermissionsRule.py
+++ b/src/ansiblelint/rules/MissingFilePermissionsRule.py
@@ -22,7 +22,6 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, Set, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.testing import RunFromText
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -125,6 +124,8 @@ class MissingFilePermissionsRule(AnsibleLintRule):
 
 if "pytest" in sys.modules:  # noqa: C901
     import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
     SUCCESS_PERMISSIONS_PRESENT = '''
 - hosts: all

--- a/src/ansiblelint/rules/NoLogPasswordsRule.py
+++ b/src/ansiblelint/rules/NoLogPasswordsRule.py
@@ -17,7 +17,6 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ansiblelint.rules import AnsibleLintRule
-from ansiblelint.testing import RunFromText
 from ansiblelint.utils import convert_to_boolean
 
 if TYPE_CHECKING:
@@ -72,6 +71,8 @@ class NoLogPasswordsRule(AnsibleLintRule):
 
 if "pytest" in sys.modules:
     import pytest
+
+    from ansiblelint.testing import RunFromText  # pylint: disable=ungrouped-imports
 
     NO_LOG_UNUSED = '''
 - hosts: all


### PR DESCRIPTION
Some of the rules were importing test code even outside of the testing block. This fixes that so there are no unintended side-effects of importing the testing code.

In particular, importing that testing code should be delayed so that `prepare_environment()` doesn't get called when importing the rule:
https://github.com/ansible-community/ansible-lint/blob/main/src/ansiblelint/testing/__init__.py#L19-L21
It probably doesn't make a difference, but it was a code smell, so this cleans that up.