### PR TITLE
Add `AnsibleLintRule.matchrawtask()`

### DIFF
--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -22,6 +22,7 @@ class BaseRule:
     severity: str = ""
     link: str = ""
     has_dynamic_tags: bool = False
+    needs_raw_task: bool = False
 
     def getmatches(self, file: "Lintable") -> List["MatchError"]:
         """Return all matches while ignoring exceptions."""
@@ -44,6 +45,20 @@ class BaseRule:
     def matchlines(self, file: "Lintable") -> List["MatchError"]:
         """Return matches found for a specific line."""
         return []
+
+    def matchrawtask(
+        self,
+        raw_task: Dict[str, Any],
+        task: Dict[str, Any],
+        file: "Optional[Lintable]" = None,
+    ) -> Union[bool, str]:
+        """Confirm if current rule is matching a specific raw task.
+
+        `raw_task` is a task that has not been normalized.
+        `task` is the normalized task (as parsed by ansible).
+        This will run instead of matchtask if needs_raw_task is True.
+        """
+        return False
 
     def matchtask(
         self, task: Dict[str, Any], file: "Optional[Lintable]" = None

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -54,9 +54,9 @@ class BaseRule:
     ) -> Union[bool, str]:
         """Confirm if current rule is matching a specific raw task.
 
-        `raw_task` is a task that has not been normalized.
-        `task` is the normalized task (as parsed by ansible).
-        This will run instead of matchtask if needs_raw_task is True.
+        ``raw_task`` is a task that has not been normalized.
+        ``task`` is the normalized task (as parsed by ansible).
+        This will run instead of ``matchtask`` if ``needs_raw_task`` is True.
         """
         return False
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -117,7 +117,10 @@ class AnsibleLintRule(BaseRule):
             if skipped or 'action' not in task:
                 continue
 
-            result = self.matchtask(task, file=file)
+            if self.needs_raw_task:
+                result = self.matchrawtask(raw_task, task, file=file)
+            else:
+                result = self.matchtask(task, file=file)
 
             if not result:
                 continue


### PR DESCRIPTION
This allows rules to opt-in to an alternate version of `matchtask()`.
To use it, rules set `needs_raw_task = True` at the class level.
That triggers using `matchrawtask()` instead of `matchtask()`.

For one of the rules I'm developing, I need to inspect the raw (not normalized via ansible) task to identify the target issue.
This rule flags tasks that use action shorthand. `normalize_task()`, however, parses the shorthand and puts it in `task['action']`, so there's no good way to detect the action shorthand with the current `matchtask()` interface. There are a variety of awkward workarounds like parsing the playbooks myself, but I would really like to take advantage of all the work `ansible-lint` already does to find the relevant tasks and skip them as needed.
https://github.com/cognifloyd/ansible-lint/blob/fmt/src/ansiblelint/rules/TaskNoActionShorthand.py

For more discussion about this no-action-shorthand rule, see: https://github.com/ansible-community/ansible-lint/discussions/1609

This is extracted from #1805 (the TaskNoActionShorthand rule will also be extracted from #1805).

I created an alternative implementation in #1834. Only one of the PRs should be merged.