### PR TITLE
Strip ./ from discover_lintables results

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -261,13 +261,20 @@ def discover_lintables(options: Namespace) -> Dict[str, Any]:
     if out is None:
         exclude_pattern = "|".join(str(x) for x in options.exclude_paths)
         _logger.info("Looking up for files, excluding %s ...", exclude_pattern)
-        out = set(
-            WcMatch(
+        # remove './' prefix from output of WcMatch
+        out = {
+            strip_dotslash_prefix(fname)
+            for fname in WcMatch(
                 '.', exclude_pattern=exclude_pattern, flags=RECURSIVE, limit=256
             ).match()
-        )
+        }
 
     return OrderedDict.fromkeys(sorted(out))
+
+
+def strip_dotslash_prefix(fname: str) -> str:
+    """Remove ./ leading from filenames."""
+    return fname[2:] if fname.startswith('./') else fname
 
 
 def guess_project_dir(config_file: Optional[str]) -> str:


### PR DESCRIPTION
calling WcMatch('.', ...) causes the resulting file names to be prefixed
with `./`.
If the tests are run in a git-repository, this is not an issue, as git
is preferred of WcMatch in the code.

Therefore remove the `./` prefix from the WcMatch return value to get
the identical expected output.

fixes ansible-community/ansible-lint#1836
