### PR TITLE
Correcting formatting of sample .ansible-lint config

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,8 +3,8 @@
 # and not relative to the CWD of execution. CLI arguments passed to the --exclude
 # option will be parsed relative to the CWD of execution.
 exclude_paths:
-- .cache/  # implicit unless exclude_paths is defined in config
-- .github/
+  - .cache/  # implicit unless exclude_paths is defined in config
+  - .github/
 # parseable: true
 # quiet: true
 # verbosity: 1


### PR DESCRIPTION
`.ansible-lint:6: yaml wrong indentation: expected 2 but found 0 (indentation)`