### PR TITLE
Enable testing using WSL1

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -94,6 +94,9 @@ jobs:
   unit:
     name: ${{ matrix.name || matrix.tox_env }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell || 'bash'}}
     strategy:
       fail-fast: false
       # max-parallel: 5
@@ -119,6 +122,10 @@ jobs:
         - tox_env: py36
           os: ubuntu-20.04
           python-version: 3.6
+        - name: py39 (wsl)
+          tox_env: py39
+          os: windows-latest
+          shell: "wsl-bash {0}"
         - tox_env: py37
           os: ubuntu-20.04
           python-version: 3.7
@@ -146,26 +153,34 @@ jobs:
     env:
       TOX_PARALLEL_NO_SPINNER: 1
       FORCE_COLOR: 1
+      # vars safe to be passed to wsl:
+      WSLENV: FORCE_COLOR:TOXENV:TOX_PARALLEL_NO_SPINNER
 
     steps:
+
+    - name: Activate WSL1
+      if: "contains(matrix.shell, 'wsl')"
+      uses: Vampire/setup-wsl@v1
+
     - name: MacOS workaround for https://github.com/actions/virtual-environments/issues/1187
       if: ${{ matrix.os == 'macOS-latest' }}
       run: |
         sudo sysctl -w net.link.generic.system.hwcksum_tx=0
         sudo sysctl -w net.link.generic.system.hwcksum_rx=0
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # needed by setuptools-scm
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: >-
-        Log the currently selected Python
-        version info (${{ matrix.python-version }})
+
+    - name: Run ./tools/test-setup.sh
       run: |
-        python --version --version
-        which python
+        ./tools/test-setup.sh
+
     # - name: Pip cache
     #   uses: actions/cache@v1
     #   with:
@@ -214,6 +229,7 @@ jobs:
       # produce a single .coverage file at repo root
       run: coverage combine .tox/.coverage.*
     - name: Upload coverage data
+      if: "runner.os == 'Linux'"
       uses: codecov/codecov-action@v1
       with:
         name: ${{ matrix.tox_env }}


### PR DESCRIPTION
Used to test if ansible-lint can really be used with WSL1, as that is not really supported by ansible itself.

We are doing this in order as a preparatory step for enabling similar jobs in ansible-language-server and vscode-ansible with the ultimate goal of switching to WSL2 once we get our own runners.