### PR TITLE
Add json schema validator for workflows

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -240,7 +240,7 @@ jobs:
     - linters
     - unit
 
-    runs-on: Ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,10 @@ ci:
   - pip-compile-docs-upgrade
   - pip-compile-upgrade
 repos:
+- repo: https://github.com/sirosen/check-jsonschema
+  rev: 0.10.2
+  hooks:
+  - id: check-github-workflows
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
   rev: v4.0.1
   hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -77,9 +77,13 @@ commands =
 passenv =
   {[testenv]passenv}
   PRE_COMMIT_HOME
+setenv =
+  {[testenv]setenv}
+  # avoid messing pre-commit with out own constraints
+  PIP_CONSTRAINT=
 
 [testenv:deps]
-description = Bump all test depeendencies
+description = Bump all test dependencies
 # we reuse the lint environment
 envdir = {toxworkdir}/lint
 skip_install = true


### PR DESCRIPTION
Required fix in tox.ini is needed because our constraints affected installation of the new hook. I am surprised that they did not affect others so far.