### PR TITLE
Remove support for py36 and py37

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -112,8 +112,6 @@ jobs:
       matrix:
         python-version:
         # keep list sorted as it determines UI order too
-        - 3.6
-        - 3.7
         - 3.8
         - 3.9
         - "3.10"
@@ -123,18 +121,12 @@ jobs:
         # - windows-latest
         # - windows-2016
         include:
-        - tox_env: py36
-          os: ubuntu-20.04
-          python-version: 3.6
         # Disabled due to gettings stuck and timeouts not working
         # https://github.com/Vampire/setup-wsl/discussions/25
         # - name: py39 (wsl)
         #   tox_env: py39
         #   os: windows-latest
         #   shell: "wsl-bash {0}"
-        - tox_env: py37
-          os: ubuntu-20.04
-          python-version: 3.7
         - tox_env: py38
           os: ubuntu-20.04
           python-version: 3.8
@@ -148,10 +140,10 @@ jobs:
           python-version: "3.10"
           devel: true
           skip_ansible29: true
-        - name: py36 (macos)
-          tox_env: py36
+        - name: py38 (macos)
+          tox_env: py38
           os: macOS-latest
-          python-version: 3.6
+          python-version: 3.8
         - name: py310 (macos)
           tox_env: py310
           os: macOS-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.6
+python_requires = >=3.8
 package_dir =
   = src
 packages = find:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
   packaging
   py310-{core,devel}
   py{39,38}-{core,ansible29,devel}
-  py{37,36}-{core,ansible29}
 isolated_build = true
 requires =
   setuptools >= 41.4.0


### PR DESCRIPTION
As part of reduce testing complexity and getting ansible-lint in sync with `ansible-core`, we will require `python_version>=3.8`.

This change marks the start of `6.x` and once is merged we will create a `stable/5.x` for the last comment before it. That branch will be used to backport changes needed for the older versions, at least until we can make a full release of 6.x.

One additional reason for making this move is a recent explosion of dependencies dropping support for py36 or even py37: `pytest`, `coverage`, `pip-compile`, `tomli`.

Please mark your support or lack of on this change as we are aware that it may upset some users that are still stuck on older platform as it will be harder for them to get bugfixes.

Related: https://github.com/ansible-community/molecule/pull/3436