### PR TITLE
Move `__main__.report_outcome()` to `App.report_outcome()`

### DIFF
--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -208,7 +208,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     app.render_matches(result.matches)
 
-    return app.report_outcome(result, mark_as_success=mark_as_success, options=options)
+    return app.report_outcome(result, mark_as_success=mark_as_success)
 
 
 @contextmanager

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -27,7 +27,6 @@ import os
 import pathlib
 import subprocess
 import sys
-from argparse import Namespace
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
@@ -35,13 +34,7 @@ from enrich.console import should_do_markup
 
 from ansiblelint import cli
 from ansiblelint.app import App
-from ansiblelint.color import (
-    console,
-    console_options,
-    console_stderr,
-    reconfigure,
-    render_yaml,
-)
+from ansiblelint.color import console, console_options, reconfigure, render_yaml
 from ansiblelint.config import options
 from ansiblelint.constants import ANSIBLE_MISSING_RC, EXIT_CONTROL_C_RC
 from ansiblelint.file_utils import abspath, cwd, normpath
@@ -52,7 +45,6 @@ from ansiblelint.version import __version__
 if TYPE_CHECKING:
     # RulesCollection must be imported lazily or ansible gets imported too early.
     from ansiblelint.rules import RulesCollection
-    from ansiblelint.runner import LintResult
 
 
 _logger = logging.getLogger(__name__)
@@ -121,77 +113,6 @@ def initialize_options(arguments: Optional[List[str]] = None) -> None:
         os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache")),
         cache_key,
     )
-
-
-def report_outcome(  # noqa: C901
-    result: "LintResult", options: Namespace, mark_as_success: bool = False
-) -> int:
-    """Display information about how to skip found rules.
-
-    Returns exit code, 2 if errors were found, 0 when only warnings were found.
-    """
-    failures = 0
-    warnings = 0
-    msg = ""
-    matches_unignored = [match for match in result.matches if not match.ignored]
-
-    # counting
-    matched_rules = {match.rule.id: match.rule for match in matches_unignored}
-    for match in result.matches:
-        if {match.rule.id, *match.rule.tags}.isdisjoint(options.warn_list):
-            failures += 1
-        else:
-            warnings += 1
-
-    # remove unskippable rules from the list
-    for rule_id in list(matched_rules.keys()):
-        if "unskippable" in matched_rules[rule_id].tags:
-            matched_rules.pop(rule_id)
-
-    entries = []
-    for key in sorted(matched_rules.keys()):
-        if {key, *matched_rules[key].tags}.isdisjoint(options.warn_list):
-            entries.append(f"  - {key}  # {matched_rules[key].shortdesc}\n")
-    for match in result.matches:
-        if "experimental" in match.rule.tags:
-            entries.append("  - experimental  # all rules tagged as experimental\n")
-            break
-    if entries and not options.quiet:
-        console_stderr.print(
-            "You can skip specific rules or tags by adding them to your "
-            "configuration file:"
-        )
-        msg += """\
-# .ansible-lint
-warn_list:  # or 'skip_list' to silence them completely
-"""
-        msg += "".join(sorted(entries))
-
-    # Do not deprecate the old tags just yet. Why? Because it is not currently feasible
-    # to migrate old tags to new tags. There are a lot of things out there that still
-    # use ansible-lint 4 (for example, Ansible Galaxy and Automation Hub imports). If we
-    # replace the old tags, those tools will report warnings. If we do not replace them,
-    # ansible-lint 5 will report warnings.
-    #
-    # We can do the deprecation once the ecosystem caught up at least a bit.
-    # for k, v in used_old_tags.items():
-    #     _logger.warning(
-    #         "Replaced deprecated tag '%s' with '%s' but it will become an "
-    #         "error in the future.",
-    #         k,
-    #         v,
-    #     )
-
-    if result.matches and not options.quiet:
-        console_stderr.print(render_yaml(msg))
-        console_stderr.print(
-            f"Finished with {failures} failure(s), {warnings} warning(s) "
-            f"on {len(result.files)} files."
-        )
-
-    if mark_as_success or not failures:
-        return 0
-    return 2
 
 
 def _do_list(rules: "RulesCollection") -> int:
@@ -287,7 +208,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     app.render_matches(result.matches)
 
-    return report_outcome(result, mark_as_success=mark_as_success, options=options)
+    return app.report_outcome(result, mark_as_success=mark_as_success, options=options)
 
 
 @contextmanager

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -4,11 +4,13 @@ import os
 from typing import TYPE_CHECKING, Any, List, Type
 
 from ansiblelint import formatters
-from ansiblelint.color import console
+from ansiblelint.color import console, console_stderr, render_yaml
 from ansiblelint.errors import MatchError
 
 if TYPE_CHECKING:
     from argparse import Namespace
+
+    from ansiblelint.runner import LintResult
 
 
 _logger = logging.getLogger(__package__)
@@ -62,6 +64,77 @@ class App:
             formatter = formatters.AnnotationsFormatter(self.options.cwd, True)
             for match in matches:
                 console.print(formatter.format(match), markup=False, highlight=False)
+
+    @staticmethod
+    def report_outcome(  # noqa: C901
+        result: "LintResult", options: "Namespace", mark_as_success: bool = False
+    ) -> int:
+        """Display information about how to skip found rules.
+
+        Returns exit code, 2 if errors were found, 0 when only warnings were found.
+        """
+        failures = 0
+        warnings = 0
+        msg = ""
+        matches_unignored = [match for match in result.matches if not match.ignored]
+
+        # counting
+        matched_rules = {match.rule.id: match.rule for match in matches_unignored}
+        for match in result.matches:
+            if {match.rule.id, *match.rule.tags}.isdisjoint(options.warn_list):
+                failures += 1
+            else:
+                warnings += 1
+
+        # remove unskippable rules from the list
+        for rule_id in list(matched_rules.keys()):
+            if "unskippable" in matched_rules[rule_id].tags:
+                matched_rules.pop(rule_id)
+
+        entries = []
+        for key in sorted(matched_rules.keys()):
+            if {key, *matched_rules[key].tags}.isdisjoint(options.warn_list):
+                entries.append(f"  - {key}  # {matched_rules[key].shortdesc}\n")
+        for match in result.matches:
+            if "experimental" in match.rule.tags:
+                entries.append("  - experimental  # all rules tagged as experimental\n")
+                break
+        if entries and not options.quiet:
+            console_stderr.print(
+                "You can skip specific rules or tags by adding them to your "
+                "configuration file:"
+            )
+            msg += """\
+# .ansible-lint
+warn_list:  # or 'skip_list' to silence them completely
+"""
+            msg += "".join(sorted(entries))
+
+        # Do not deprecate the old tags just yet. Why? Because it is not currently feasible
+        # to migrate old tags to new tags. There are a lot of things out there that still
+        # use ansible-lint 4 (for example, Ansible Galaxy and Automation Hub imports). If we
+        # replace the old tags, those tools will report warnings. If we do not replace them,
+        # ansible-lint 5 will report warnings.
+        #
+        # We can do the deprecation once the ecosystem caught up at least a bit.
+        # for k, v in used_old_tags.items():
+        #     _logger.warning(
+        #         "Replaced deprecated tag '%s' with '%s' but it will become an "
+        #         "error in the future.",
+        #         k,
+        #         v,
+        #     )
+
+        if result.matches and not options.quiet:
+            console_stderr.print(render_yaml(msg))
+            console_stderr.print(
+                f"Finished with {failures} failure(s), {warnings} warning(s) "
+                f"on {len(result.files)} files."
+            )
+
+        if mark_as_success or not failures:
+            return 0
+        return 2
 
 
 def choose_formatter_factory(

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -65,9 +65,8 @@ class App:
             for match in matches:
                 console.print(formatter.format(match), markup=False, highlight=False)
 
-    @staticmethod
     def report_outcome(  # noqa: C901
-        result: "LintResult", options: "Namespace", mark_as_success: bool = False
+        self, result: "LintResult", mark_as_success: bool = False
     ) -> int:
         """Display information about how to skip found rules.
 
@@ -81,7 +80,7 @@ class App:
         # counting
         matched_rules = {match.rule.id: match.rule for match in matches_unignored}
         for match in result.matches:
-            if {match.rule.id, *match.rule.tags}.isdisjoint(options.warn_list):
+            if {match.rule.id, *match.rule.tags}.isdisjoint(self.options.warn_list):
                 failures += 1
             else:
                 warnings += 1
@@ -93,13 +92,13 @@ class App:
 
         entries = []
         for key in sorted(matched_rules.keys()):
-            if {key, *matched_rules[key].tags}.isdisjoint(options.warn_list):
+            if {key, *matched_rules[key].tags}.isdisjoint(self.options.warn_list):
                 entries.append(f"  - {key}  # {matched_rules[key].shortdesc}\n")
         for match in result.matches:
             if "experimental" in match.rule.tags:
                 entries.append("  - experimental  # all rules tagged as experimental\n")
                 break
-        if entries and not options.quiet:
+        if entries and not self.options.quiet:
             console_stderr.print(
                 "You can skip specific rules or tags by adding them to your "
                 "configuration file:"
@@ -125,7 +124,7 @@ warn_list:  # or 'skip_list' to silence them completely
         #         v,
         #     )
 
-        if result.matches and not options.quiet:
+        if result.matches and not self.options.quiet:
             console_stderr.print(render_yaml(msg))
             console_stderr.print(
                 f"Finished with {failures} failure(s), {warnings} warning(s) "


### PR DESCRIPTION
Reporting matches and summarizing results is related. So, I think moving `report_outcome` to a method on `app.App` makes sense. This also made it simple to extract some of the logic to simplify the method and remove another "noqa: C901" comment.

- Move `__main__.report_outcome` to `app.App.report_outcome`
- have `report_outcome` get options from `App.options`
- Extract `count_results` from `report_outcome`
