### PR TITLE
test: fix GHA job names

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,4 +1,4 @@
-name: gh
+name: tox
 
 on:
   create:  # is used for publishing to PyPI and TestPyPI
@@ -142,10 +142,12 @@ jobs:
           python-version: "3.10"
           devel: true
           skip_ansible29: true
-        - tox_env: py36
+        - name: py36 (macos)
+          tox_env: py36
           os: macOS-latest
           python-version: 3.6
-        - tox_env: py310
+        - name: py310 (macos)
+          tox_env: py310
           os: macOS-latest
           python-version: "3.10"
           skip_ansible29: true


### PR DESCRIPTION
- Ensure pipeline name matches filename which defines it ("gh" was
  not informative at all (everything under .github is gh)
- Correct name regression from #1848 where we lost the macos from being
  listed in the matrix job name. Linux is implicit as being the
  default platform.