### PR TITLE
Add `Lintable.open()` a change detecting wrapper around `Path.open()`

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -237,11 +237,13 @@ class Lintable:
         """
         if mode in ["r", "rt", "rb"]:
             # Just reading. No need to detect changes.
-            yield self.path.open(mode, buffering, encoding, errors, newline)
+            with self.path.open(mode, buffering, encoding, errors, newline) as f:
+                yield f
             return
         pre_write_hash = self.content_hash()
         try:
-            yield self.path.open(mode, buffering, encoding, errors, newline)
+            with self.path.open(mode, buffering, encoding, errors, newline) as f:
+                yield f
         finally:
             post_write_hash = self.content_hash()
             if pre_write_hash != post_write_hash:

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -235,7 +235,7 @@ class Lintable:
 
         This must be used as a context manager (``with lintable.open() as f:``).
         """
-        if "r" in mode:
+        if mode in ["r", "rt", "rb"]:
             # Just reading. No need to detect changes.
             yield self.path.open(mode, buffering, encoding, errors, newline)
             return

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -240,11 +240,13 @@ class Lintable:
             yield self.path.open(mode, buffering, encoding, errors, newline)
             return
         pre_write_hash = self.content_hash()
-        yield self.path.open(mode, buffering, encoding, errors, newline)
-        post_write_hash = self.content_hash()
-        if pre_write_hash != post_write_hash:
-            self.contents_changed = True  # signal that the file has been updated
-            self._content = None  # reset contents cache so next access gets the update
+        try:
+            yield self.path.open(mode, buffering, encoding, errors, newline)
+        finally:
+            post_write_hash = self.content_hash()
+            if pre_write_hash != post_write_hash:
+                self.contents_changed = True  # signal that the file has been updated
+                self._content = None  # reset internal content cache
 
     def __hash__(self) -> int:
         """Return a hash value of the lintables."""


### PR DESCRIPTION
As part of introducing formatting and transforms (see #1828), we need a way to detect changes in lintables.

By introducing a `Lintable.open()`, we can ensure that
1. we can detect when changes occur, and 
2. we can reset the internal content cache on change.

The goal of this PR is to achieve (1). (2) is a happy bonus that comes from tracking when the file gets modified.
So, I'm open to any alternative implementation that allows me to detect that the contents change.

Relevant scenarios to consider:
- File is updated to replace `"` with `'`.
- A file is round-tripped (a read/write cycle) without changing its contents. This should not trigger change detection.