### PR TITLE
Run in an un-activated virtual environment, fixes #1507

### DIFF
--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -1,7 +1,6 @@
 """Store configuration options as a singleton."""
 import os
 import re
-import subprocess
 import sys
 from argparse import Namespace
 from functools import lru_cache
@@ -10,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from packaging.version import Version
 
 from ansiblelint.constants import ANSIBLE_MISSING_RC
+from ansiblelint.venv_utils import run_ansible_version
 
 DEFAULT_KINDS = [
     # Do not sort this list, order matters.
@@ -143,13 +143,7 @@ def ansible_version(version: str = "") -> Version:
     to Version object in order to make it usable in comparisons.
     """
     if not version:
-        proc = subprocess.run(
-            ["ansible", "--version"],
-            universal_newlines=True,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        proc = run_ansible_version()
         if proc.returncode == 0:
             version, error = parse_ansible_version(proc.stdout)
             if error is not None:

--- a/src/ansiblelint/prerun.py
+++ b/src/ansiblelint/prerun.py
@@ -28,6 +28,7 @@ from ansiblelint.constants import (
     INVALID_PREREQUISITES_RC,
 )
 from ansiblelint.loaders import yaml_from_file
+from ansiblelint.venv_utils import add_venv_path, run_ansible_version
 
 _logger = logging.getLogger(__name__)
 
@@ -45,12 +46,7 @@ def check_ansible_presence(exit_on_error: bool = False) -> Tuple[str, str]:
         err = ""
         failed = False
         ver = ""
-        result = subprocess.run(
-            args=["ansible", "--version"],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-            check=False,
-        )
+        result = run_ansible_version()
         if result.returncode != 0:
             return (
                 ver,
@@ -103,7 +99,7 @@ def install_collection(collection: str, destination: Optional[str] = None) -> No
     Can accept version constraints like 'foo.bar:>=1.2.3'
     """
     cmd = [
-        "ansible-galaxy",
+        add_venv_path("ansible-galaxy"),
         "collection",
         "install",
         "--force",  # required for ansible 2.9
@@ -138,7 +134,7 @@ def install_requirements(requirement: str) -> None:
         return
 
     cmd = [
-        "ansible-galaxy",
+        add_venv_path("ansible-galaxy"),
         "role",
         "install",
         "--force",  # required for ansible 2.9
@@ -164,7 +160,7 @@ def install_requirements(requirement: str) -> None:
     if "collections" in yaml_from_file(requirement):
 
         cmd = [
-            "ansible-galaxy",
+            add_venv_path("ansible-galaxy"),
             "collection",
             "install",
             "--force",  # required for ansible 2.9
@@ -432,7 +428,7 @@ def ansible_config_get(key: str, kind: Type[Any] = str) -> Union[str, List[str],
         env.pop(colpathvar)
 
     config = subprocess.check_output(
-        ["ansible-config", "dump"], universal_newlines=True, env=env
+        [add_venv_path("ansible-config"), "dump"], universal_newlines=True, env=env
     )
 
     if kind == str:

--- a/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
+++ b/src/ansiblelint/rules/AnsibleSyntaxCheckRule.py
@@ -12,6 +12,7 @@ from ansiblelint.file_utils import Lintable
 from ansiblelint.logger import timed_info
 from ansiblelint.rules import AnsibleLintRule
 from ansiblelint.text import strip_ansi_escape
+from ansiblelint.venv_utils import add_venv_path
 
 DESCRIPTION = """\
 Running ``ansible-playbook --syntax-check ...`` failed.
@@ -57,7 +58,7 @@ class AnsibleSyntaxCheckRule(AnsibleLintRule):
             if options.extra_vars:
                 extra_vars_cmd = ["--extra-vars", json.dumps(options.extra_vars)]
             cmd = [
-                "ansible-playbook",
+                add_venv_path("ansible-playbook"),
                 "--syntax-check",
                 *extra_vars_cmd,
                 str(lintable.path),

--- a/src/ansiblelint/venv_utils.py
+++ b/src/ansiblelint/venv_utils.py
@@ -1,0 +1,54 @@
+"""Utilities supporting virtual environments."""
+
+# We run various ansible command line tools (and detect the ansible version
+# by executing `ansible --version`).
+# The executable we want to run may not be in $PATH, especially if we
+# are running in a virtual environment that's not been activated.
+
+import os
+import pathlib
+import subprocess
+import sys
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, List
+
+if TYPE_CHECKING:
+    # https://github.com/PyCQA/pylint/issues/3240
+    # pylint: disable=unsubscriptable-object
+    CompletedProcess = subprocess.CompletedProcess[Any]
+else:
+    CompletedProcess = subprocess.CompletedProcess
+
+
+def _normalize(path: str) -> pathlib.Path:
+    # pathlib.Path takes care of MS Windows case-insensitivity
+    return pathlib.Path(os.path.realpath(os.path.normpath(os.path.expanduser(path))))
+
+
+def _get_search_path() -> List[pathlib.Path]:
+    return [_normalize(path) for path in os.get_exec_path()]
+
+
+@lru_cache()
+def _get_venv_path() -> str:
+    venv_dir = _normalize(os.path.dirname(sys.executable))
+    search_path = _get_search_path()
+    if venv_dir in search_path or search_path and search_path[0] == pathlib.Path("."):
+        return ""
+    return str(venv_dir)
+
+
+def add_venv_path(cmd: str) -> str:
+    """Prepend the path to the venv, if any, to the supplied command."""
+    return os.path.join(_get_venv_path(), cmd)
+
+
+def run_ansible_version() -> CompletedProcess:
+    """Run `ansible --version` and return the result."""
+    return subprocess.run(
+        args=[add_venv_path("ansible"), "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )


### PR DESCRIPTION
Fix so the command line ansible-lint will run in an un-activated virtual environment, via a pathname supplied to the shell.  Fixes issue #1507.

THEORY:
The foundational observation is that because activating a virtual environment does only one thing, add a path to the venv's $PATH, the only thing we know about an un-activated venv is that the venv[0] of it's process is either not in a $PATH directory or, if it is, then the venv is, in effect, activated.  Therefore the only way to possibly test for virtual environment activation is to check venv[0] against $PATH. 

The underlying premise is that if it is necessary to specify a path, one that contains directories, to execute the python which runs ansible-lint, then the other ansible-* commands run by ansible-lint reside in the os.path.basedir() of that directory.  Alternatively, given that the operational test to determine if ansible-lint is running in an un-activated virtual environment is whether a path containing a directory designation is required to execute the running ansible-lint, then, having decided that this is the case, use the directory designation to execute the other ansible-* commands of the ansible-lint's virtual environment.

The approach taken here is a heuristic, one which I believe is explicit and clear.  The alternative, as far as I've been able to imagine, is to fallback to trying to execute in an un-activated venv as a fallback after the search through $PATH fails.   (Or vice-versa.) This also is a heuristic.  Comparison without code is uninteresting, but it seems to me that the corner cases that fail using either heuristic would involve the case of someone running some ansible-* commands in some system/virtual environments and some in another.  It might make sense to simply declare this a configuration that is not supported.

PRACTICE:
Obtains directory portion of sys.executable and checks if it is an element of $PATH.  If so the system can rely on $PATH to discover all executables; the original codepath is used and basenames are the argv[0] given to subprocess.run().  If not then the Python binary was run with a non-trivial pathname, as when executing a binary in an un-activated virtual environment's bin directory; the directory portion of sys.executable is prefaced to argv[[0] when executing ansible-related commands.

Testing is done by monkeypatching to remove the element of $PATH which tox adds to activate the virtual environment.  Existing tests which run the ansible-lint executable were modified to run twice, once as-is and a 2nd time with the virtual environment deactivated.  

Further, to directly test what a user would do, one test was also modified to, in addition to existing codepaths, run the ansible-lint executable installed in the tox virtual environment.  The existing test runs via 'python -m ansiblelint'.
