### PR TITLE
Remove support for ansible 2.9

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -139,7 +139,6 @@ jobs:
           os: ubuntu-20.04
           python-version: "3.10"
           devel: true
-          skip_ansible29: true
         - name: py38 (macos)
           tox_env: py38
           os: macOS-latest
@@ -148,7 +147,6 @@ jobs:
           tox_env: py310
           os: macOS-latest
           python-version: "3.10"
-          skip_ansible29: true
 
     env:
       TOX_PARALLEL_NO_SPINNER: 1
@@ -206,19 +204,13 @@ jobs:
         --skip-missing-interpreters false
         -vv
       env:
-        TOXENV: ${{ matrix.tox_env }}-core,${{ matrix.tox_env }}-ansible29
+        TOXENV: ${{ matrix.tox_env }}-core
     # sequential run improves browsing experience (almost no speed impact)
     - name: "Test with tox: ${{ matrix.tox_env }}-core"
       run: |
         python3 -m tox
       env:
         TOXENV: ${{ matrix.tox_env }}-core
-    - name: "Test with tox: ${{ matrix.tox_env }}-ansible29"
-      if: ${{ !matrix.skip_ansible29 }}
-      run: |
-        python3 -m tox
-      env:
-        TOXENV: ${{ matrix.tox_env }}-ansible29
     - name: "Test with tox: ${{ matrix.tox_env }}-devel"
       if: ${{ matrix.devel }}
       run: |

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -38,7 +38,7 @@ to create a new rule by following the steps below:
 * If the rule is task specific, it may be best to include a test to verify its
   use inside blocks as well.
 * Optionally run only the rule specific tests with a command like:
-  :command:`tox -e py38-ansible29 -- -k NewRule`
+  :command:`tox -e py38-core -- -k NewRule`
 * Run :command:`tox` in order to run all ansible-lint tests. Adding a new rule
   can break some other tests. Update them if needed.
 * Run :command:`ansible-lint -L` and check that the rule description renders

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ minversion = 3.16.1
 envlist =
   lint
   packaging
-  py310-{core,devel}
-  py{39,38}-{core,ansible29,devel}
+  py{310,39,38}-{core,devel}
 isolated_build = true
 requires =
   setuptools >= 41.4.0
@@ -15,12 +14,10 @@ skip_missing_interpreters = True
 description =
   Run the tests under {basepython} and
   devel: ansible devel branch
-  ansible29: ansible 2.9
   core: ansible-core 2.11+
 deps =
   --editable .[yamllint,test]
   core: ansible-core
-  ansible29: ansible>=2.9,<2.10
   py: ansible-core>=2.11
   devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
 commands =


### PR DESCRIPTION
That move prepares for making ansible-core a direct dependency. We
will remove other internals in follow-ups as these are not directly
required by this change.

Related: https://github.com/ansible-community/ansible-lint/discussions/1832