### PR TITLE
Removed --parseable-severity feature

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -157,8 +157,6 @@ def choose_formatter_factory(
     r: Type[formatters.BaseFormatter[Any]] = formatters.Formatter
     if options_list.format == "quiet":
         r = formatters.QuietFormatter
-    elif options_list.parseable_severity:
-        r = formatters.ParseableSeverityFormatter
     elif options_list.format == "codeclimate":
         r = formatters.CodeclimateJSONFormatter
     elif options_list.parseable or options_list.format == "pep8":

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -158,13 +158,6 @@ def get_cli_parser() -> argparse.ArgumentParser:
         help="parseable output, same as '-f pep8'",
     )
     parser.add_argument(
-        "--parseable-severity",
-        dest="parseable_severity",
-        default=False,
-        action="store_true",
-        help="parseable output including severity of rule",
-    )
-    parser.add_argument(
         "--progressive",
         dest="progressive",
         default=False,
@@ -296,7 +289,6 @@ def merge_config(file_config: Dict[Any, Any], cli_config: Namespace) -> Namespac
     bools = (
         "display_relative_path",
         "parseable",
-        "parseable_severity",
         "quiet",
         "use_default_rules",
         "progressive",

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -70,7 +70,6 @@ options = Namespace(
     listrules=False,
     listtags=False,
     parseable=False,
-    parseable_severity=False,
     quiet=False,
     rulesdirs=[],
     skip_list=[],

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -139,21 +139,6 @@ class AnnotationsFormatter(BaseFormatter):  # type: ignore
         return "error"
 
 
-class ParseableSeverityFormatter(BaseFormatter[Any]):
-    def format(self, match: "MatchError") -> str:
-
-        filename = self._format_path(match.filename or "")
-        position = match.position
-        rule_id = "{0}".format(match.rule.id)
-        severity = match.rule.severity
-        message = self.escape(str(match.message))
-
-        return (
-            f"[filename]{filename}[/]:{position}: [[error_code]{rule_id}[/]] "
-            f"[[error_code]{severity}[/]] [dim]{message}[/]"
-        )
-
-
 class CodeclimateJSONFormatter(BaseFormatter[Any]):
     """Formatter for emitting violations in Codeclimate JSON report format.
 

--- a/src/ansiblelint/rules/VariableNamingRule.py
+++ b/src/ansiblelint/rules/VariableNamingRule.py
@@ -36,9 +36,7 @@ class VariableNamingRule(AnsibleLintRule):
     base_msg = "All variables should be named using only lowercase and underscores"
     shortdesc = base_msg
     description = "All variables should be named using only lowercase and underscores"
-    severity = (
-        "MEDIUM"  # ansible-lint displays severity when with --parseable-severity option
-    )
+    severity = "MEDIUM"
     tags = ["idiom", "experimental"]
     version_added = "v5.0.10"
 


### PR DESCRIPTION
Removes the unorthodox CLI option and output format as we have other standard file output formats that also include the same information and they are considerably more flexible.

This will simplify both the implementation and also the list of command line arguments the tool accepts. This will be followed up by another change that will also remove the `-p` argument as that was kept as alias for `-f pep8` for long time.

Fixes: #1732