### PR TITLE
Moved some pytest options to tox

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,22 +1,9 @@
 # spell-checker:ignore filterwarnings norecursedirs optionflags
 [pytest]
 addopts =
-    # `pytest-xdist`:
-    -n auto
-
-    # `pytest-mon`:
-    # useful for live testing with `pytest-watch` during development:
-    # --testmon
-
-    # flaky:
-    --no-success-flaky-report
-
-    --durations=10
     -ra
     --showlocals
     --doctest-modules
-    --junitxml=.test-results/pytest/results.xml
-
     # interpret all the target args as things that can be imported:
     --pyargs
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,16 +25,18 @@ commands =
   {envpython} -m pip check
   # We add coverage options but not making them mandatory as we do not want to force
   # pytest users to run coverage when they just want to run a single test with `pytest -k test`
-  {envpython} -m pytest \
-  --junitxml "{toxworkdir}/junit.{envname}.xml" \
-  {posargs:\
-    -n0 \
+  {envpython} -m pytest {posargs:\
+    -n auto \
+    --no-success-flaky-report \
+    --durations=10 \
     -m "not eco" \
     -p pytest_cov \
     --cov ansiblelint \
     --cov "{envsitepackagesdir}/ansiblelint" \
     --cov-report term-missing:skip-covered \
-    --no-cov-on-fail}
+    --no-cov-on-fail \
+    --junitxml "{toxworkdir}/junit.{envname}.xml" \
+    }
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
   FORCE_COLOR


### PR DESCRIPTION
- Ensures that direct call of pytest will run without xdist
- Runs with xdist only when tox or pytest do not receive extra args
- Avoid extra reporting options when run directly