### PR TITLE
Do not force pytest to always run all tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,22 +1,9 @@
 # spell-checker:ignore filterwarnings norecursedirs optionflags
 [pytest]
 addopts =
-    # `pytest-xdist`:
-    -n auto
-
-    # `pytest-mon`:
-    # useful for live testing with `pytest-watch` during development:
-    # --testmon
-
-    # flaky:
-    --no-success-flaky-report
-
-    --durations=10
     -ra
     --showlocals
     --doctest-modules
-    --junitxml=.test-results/pytest/results.xml
-
     # interpret all the target args as things that can be imported:
     --pyargs
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,8 +7,8 @@ addopts =
     # interpret all the target args as things that can be imported:
     --pyargs
 
-    # importable packages for test lookup:
-    test ansiblelint.rules
+	# pytest will collect most tests from either `tests` or `ansiblelint.rules`.
+	# It also collects doctests from other modules.
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,7 +8,7 @@ addopts =
     --pyargs
 
 	# pytest will collect most tests from either `tests` or `ansiblelint.rules`.
-	# It also collects doctests from other modules.
+	# It also collects doctest from other modules.
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error

--- a/tox.ini
+++ b/tox.ini
@@ -25,16 +25,18 @@ commands =
   {envpython} -m pip check
   # We add coverage options but not making them mandatory as we do not want to force
   # pytest users to run coverage when they just want to run a single test with `pytest -k test`
-  {envpython} -m pytest \
-  --junitxml "{toxworkdir}/junit.{envname}.xml" \
-  {posargs:\
-    -n0 \
+  {envpython} -m pytest {posargs:\
+    -n auto \
+    --no-success-flaky-report \
+    --durations=10 \
     -m "not eco" \
     -p pytest_cov \
     --cov ansiblelint \
     --cov "{envsitepackagesdir}/ansiblelint" \
     --cov-report term-missing:skip-covered \
-    --no-cov-on-fail}
+    --no-cov-on-fail \
+    --junitxml "{toxworkdir}/junit.{envname}.xml" \
+    }
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
   FORCE_COLOR


### PR DESCRIPTION
I run pytest within pycharm. PyCharm handles automatically adding the src dir to the PYTHONPATH so that I do not have to install the lib and have duplicate files. That also simplifies navigating the code as the IDE never gets confused about which copy I want to jump to.

However, if I leave `test ansiblelint.rules` in pytest.ini then pytest always tries to run all tests. So, if I select a single test I'm trying to run during development, pytest runs all of the tests instead.

So, I've had to consistently comment that out, which makes git complain that my checkout is not clean, and just makes my development experience worse.

Also, we currently have `--doctest-modules` in the args, but pytest doesn't find one of the doctest modules because it is not under `tests` or `ansiblelint.rules`. It's in the `ansiblelint.yaml_utils`. Getting rid of the hard-coded `tests ansiblelint.rules` modules allows pytest to truly discover all relevant tests.

Note: I built this on top of #1909. It should be rebased on main once #1909 is merged.
