### PR TITLE
Use pathlib methods instead of `open()` in Lintable

### DIFF
--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -257,8 +257,7 @@ class Lintable:
         if not force and not self.updated:
             # No changes to write.
             return
-        with self.path.resolve().open(mode="w", encoding="utf-8") as file:
-            file.write(self._content or "")
+        self.path.resolve().write_text(self._content or "")
 
     def __hash__(self) -> int:
         """Return a hash value of the lintables."""

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -256,7 +256,7 @@ class Lintable:
         if not force and not self.updated:
             # No changes to write.
             return
-        self.path.resolve().write_text(self._content or "")
+        self.path.resolve().write_text(self._content or "", encoding="utf-8")
 
     def __hash__(self) -> int:
         """Return a hash value of the lintables."""

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -199,8 +199,7 @@ class Lintable:
             return default
 
     def _populate_content_cache_from_disk(self) -> None:
-        with self.path.resolve().open(mode="r", encoding="utf-8") as f:
-            self._content = f.read()
+        self._content = self.path.resolve().read_text(encoding="utf-8")
         if self._original_content is None:
             self._original_content = self._content
 

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -199,7 +199,7 @@ class Lintable:
             return default
 
     def _populate_content_cache_from_disk(self) -> None:
-        with open(self.path.resolve(), mode="r", encoding="utf-8") as f:
+        with self.path.resolve().open(mode="r", encoding="utf-8") as f:
             self._content = f.read()
         if self._original_content is None:
             self._original_content = self._content
@@ -257,7 +257,7 @@ class Lintable:
         if not force and not self.updated:
             # No changes to write.
             return
-        with open(self.path.resolve(), mode="w", encoding="utf-8") as file:
+        with self.path.resolve().open(mode="w", encoding="utf-8") as file:
             file.write(self._content or "")
 
     def __hash__(self) -> int:


### PR DESCRIPTION
This implements @webknjaz's suggestion in https://github.com/ansible-community/ansible-lint/pull/1884#discussion_r807262791
