### PR TITLE
Fix test integration with IDEs

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -112,6 +112,7 @@ prerun
 psutil
 pyargs
 pycache
+pycharm
 pyenv
 pygments
 pylint
@@ -187,6 +188,7 @@ xdist
 xfail
 xunit
 zuul
+
 # Contributors
 Sorin
 Sbarnea

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,14 +1,14 @@
 # spell-checker:ignore filterwarnings norecursedirs optionflags
 [pytest]
+# do not add options here as this will likely break either console runs or IDE
+# integration like vscode or pycharm
 addopts =
-    -ra
-    --showlocals
-    --doctest-modules
-    # interpret all the target args as things that can be imported:
-    --pyargs
+    # https://code.visualstudio.com/docs/python/testing
+    # coverage is re-enabled in `tox.ini`. That approach is safer than
+    # `--no-cov` which prevents activation from tox.ini and which also fails
+    # when plugin is effectively missing.
+    -p no:pytest_cov
 
-	# pytest will collect most tests from either `tests` or `ansiblelint.rules`.
-	# It also collects doctest from other modules.
 doctest_optionflags = ALLOW_UNICODE ELLIPSIS
 filterwarnings =
     error

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,9 @@ commands =
   # pytest users to run coverage when they just want to run a single test with `pytest -k test`
   {envpython} -m pytest {posargs:\
     -n auto \
+    -ra \
+    --showlocals \
+    --doctest-modules \
     --no-success-flaky-report \
     --durations=10 \
     -m "not eco" \


### PR DESCRIPTION
This should fix debugging tests in both vscode and pycharm. We need to be sure that we disable pytest-cov inside `pytest.ini` and enable it only within `tox.ini` file.

This ensures that we can:

- [x] run/debug with pytest from console (outside tox)
- [x] run/debug from vscode
- [x] run/debug from pycharm
- [x] capture coverage on CI
- [x] capture coverage with simple `tox -e py` (no posargs)

Related: #1912 #1909