### PR TITLE
Add `--write` option for upcoming reformat/transform features

### DIFF
--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -190,6 +190,13 @@ def get_cli_parser() -> argparse.ArgumentParser:
         help="Keep default rules when using -r",
     )
     parser.add_argument(
+        "--write",
+        dest="write",
+        action="store_true",
+        help="Reformat YAML files to standardize spacing, quotes, etc. "
+        "Future versions will expand this option so it fixes more issues.",
+    )
+    parser.add_argument(
         "--show-relpath",
         dest="display_relative_path",
         action="store_false",

--- a/src/ansiblelint/config.py
+++ b/src/ansiblelint/config.py
@@ -69,6 +69,7 @@ options = Namespace(
     lintables=[],
     listrules=False,
     listtags=False,
+    write=False,
     parseable=False,
     quiet=False,
     rulesdirs=[],

--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -1,0 +1,28 @@
+"""Transformer implementation."""
+import logging
+from typing import List, Set
+
+from ansiblelint.errors import MatchError
+from ansiblelint.file_utils import Lintable
+from ansiblelint.runner import LintResult
+
+__all__ = ["Transformer"]
+
+_logger = logging.getLogger(__name__)
+
+
+class Transformer:
+    """Transformer class marshals transformations.
+
+    The Transformer is similar to the ``ansiblelint.runner.Runner`` which manages
+    running each of the rules. We only expect there to be one ``Transformer`` instance
+    which should be instantiated from the main entrypoint function.
+    """
+
+    def __init__(self, result: LintResult):
+        """Initialize a Transformer instance."""
+        self.matches: List[MatchError] = result.matches
+        self.files: Set[Lintable] = result.files
+
+    def run(self) -> None:
+        """For each file, read it, execute transforms on it, then write it."""


### PR DESCRIPTION
This adds the `--write` config and cli options.
It also wires up a stub Transformer class using the `write` option.

Transforms, including read/write of YAML files, will be added in follow-up PRs.

This was extracted from #1828.
