### PR TITLE
Add json alias for codeclimate formatter

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -104,9 +104,10 @@ are also handled:
    :returncode: 2
    :nostderr:
 
-A codeclimate report in JSON format can be generated with ansible-lint.
+A ``JSON`` report, based on codeclimate specification, can be generated with
+ansible-lint.
 
-.. command-output:: ansible-lint -f codeclimate examples/playbooks/norole.yml
+.. command-output:: ansible-lint -f json examples/playbooks/norole.yml
    :cwd: ..
    :returncode: 2
    :nostderr:

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -157,7 +157,7 @@ def choose_formatter_factory(
     r: Type[formatters.BaseFormatter[Any]] = formatters.Formatter
     if options_list.format == "quiet":
         r = formatters.QuietFormatter
-    elif options_list.format == "codeclimate":
+    elif options_list.format in ("json", "codeclimate"):
         r = formatters.CodeclimateJSONFormatter
     elif options_list.parseable or options_list.format == "pep8":
         r = formatters.ParseableFormatter

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -140,8 +140,8 @@ def get_cli_parser() -> argparse.ArgumentParser:
         "-f",
         dest="format",
         default="rich",
-        choices=["rich", "plain", "rst", "codeclimate", "quiet", "pep8"],
-        help="Format used rules output, (default: %(default)s)",
+        choices=["rich", "plain", "rst", "json", "codeclimate", "quiet", "pep8"],
+        help="stdout formatting, json being an alias for codeclimate. (default: %(default)s)",
     )
     parser.add_argument(
         "-q",


### PR DESCRIPTION
As we had multiple reported feature requests for JSON output even
after we implemented the codeclimate support, we expose a `json`
option, making JSON feature easier to discover.
