### PR TITLE
Manage YAML comment indentation

### DIFF
--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -374,8 +374,8 @@ class FormattedEmitter(Emitter):
             value = self._re_repeat_blank_lines.sub("\n\n", value)
         comment.value = value
 
-        # make sure that the comment only has one space before it.
-        if comment.column > self.column + 1:
+        # make sure that the eol comment only has one space before it.
+        if comment.column > self.column + 1 and not self.whitespace:
             comment.column = self.column + 1
         return super().write_comment(comment, pre)
 

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -384,6 +384,7 @@ class FormattedEmitter(Emitter):
         else:
             # single blank lines in post comments
             value = self._re_repeat_blank_lines.sub("\n\n", value)
+        comment.value = value
 
         # make sure that the eol comment only has one space before it.
         if comment.column > self.column + 1 and not pre:
@@ -391,48 +392,53 @@ class FormattedEmitter(Emitter):
 
         # re-indent full-line comments to match prettier's format
 
-        full_line_comments = self._re_full_line_comment.search(value)
-        if full_line_comments or (pre and self.indent is not None):
+        if self._re_full_line_comment.search(value) or (
+            pre and self.indent is not None
+        ):
             # we need to re-indent full line comments to match prettier's format
-            indent = self.indent
-            first_line_is_blank = value.startswith("\n")
-            if not first_line_is_blank:
-                indent += (
-                    self.best_sequence_indent
-                    if self.indents.last_seq()
-                    else self.best_map_indent
-                )
-            value_lines = value.splitlines(keepends=True)
-            for index, line in enumerate(value_lines):
-                if (not pre and index == 0) or "#" not in line:
-                    # already covered first line with eol comment handling above
-                    # or no comment on this line
-                    continue
-                comment_start = line.index("#") if index != 0 else comment.column
+            self._mutate_full_line_comments(comment, pre)
 
-                if (
-                    index != 0  # full-line comment
-                    and value_lines[index - 1] == "\n"  # after a blank line
-                    and comment_start == 0  # at start of line
-                    and isinstance(self.event, ruamel.yaml.events.CollectionEndEvent)
-                ):
-                    # prettier does not indent comments just before top-level keys
-                    # but the emitter cannot check the next key (it does not have a
-                    # peek or lookahead). So we try to guess using blank lines.
-                    # FIXME: Find a better way that avoids more edge cases.
-                    continue
-
-                if (first_line_is_blank and comment_start > indent) or (
-                    not first_line_is_blank and comment_start != indent
-                ):
-                    if index == 0:
-                        comment.column = indent
-                    else:
-                        value_lines[index] = " " * indent + line.lstrip(" ")
-            value = "".join(value_lines)
-
-        comment.value = value
         return super().write_comment(comment, pre)
+
+    def _mutate_full_line_comments(self, comment: CommentToken, pre: bool) -> None:
+        value = comment.value
+        indent = self.indent or 0
+        first_line_is_blank = value.startswith("\n")
+        if not first_line_is_blank:
+            indent += (
+                self.best_sequence_indent
+                if self.indents.last_seq()
+                else self.best_map_indent
+            )
+        value_lines = value.splitlines(keepends=True)
+        for index, line in enumerate(value_lines):
+            if (not pre and index == 0) or "#" not in line:
+                # already covered first line with eol comment handling above
+                # or no comment on this line
+                continue
+            comment_start = line.index("#") if index != 0 else comment.column
+
+            if (
+                index != 0  # full-line comment
+                and value_lines[index - 1] == "\n"  # after a blank line
+                and comment_start == 0  # at start of line
+                and isinstance(self.event, ruamel.yaml.events.CollectionEndEvent)
+            ):
+                # prettier does not indent comments just before top-level keys
+                # but the emitter cannot check the next key (it does not have a
+                # peek or lookahead). So we try to guess using blank lines.
+                # FIXME: Find a better way that avoids more edge cases.
+                continue
+
+            if (first_line_is_blank and comment_start > indent) or (
+                not first_line_is_blank and comment_start != indent
+            ):
+                if index == 0:
+                    comment.column = indent
+                else:
+                    value_lines[index] = " " * indent + line.lstrip(" ")
+        value = "".join(value_lines)
+        comment.value = value
 
     def write_version_directive(self, version_text: Any) -> None:
         """Skip writing '%YAML 1.1'."""

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -391,8 +391,6 @@ class FormattedEmitter(Emitter):
         if comment.column > self.column + 1 and not pre:
             comment.column = self.column + 1
 
-        # re-indent full-line comments to match prettier's format
-
         if self._re_full_line_comment.search(value) or (
             pre and self.indent is not None
         ):

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -337,6 +337,7 @@ class FormattedEmitter(Emitter):
             and not self._in_empty_flow_map
         ):
             indicator = " }"
+            self._in_empty_flow_map = False
         super().write_indicator(indicator, need_whitespace, whitespace, indention)
         # if it is the start of a flow mapping, and it's not time
         # to wrap the lines, insert a space.

--- a/test/fixtures/formatting-after/fmt-3.yml
+++ b/test/fixtures/formatting-after/fmt-3.yml
@@ -1,0 +1,16 @@
+---
+dummy_map: # eol comment
+  # full line comment not indented
+  something:
+    # full line comment indented
+    # next full line comment indented
+    - or
+      # 1 full line comments over indented
+      # 2 full line comments over indented
+    - other
+
+# comment before top-level
+second_key:
+  - []
+  # comment before non top-level
+  - []

--- a/test/fixtures/formatting-after/fmt-3.yml
+++ b/test/fixtures/formatting-after/fmt-3.yml
@@ -11,6 +11,8 @@ dummy_map: # eol comment
 
 # comment before top-level
 second_key:
-  - []
+  - {} # should drop the extra space in flow map
+  # comment before non top-level
+  - {}
   # comment before non top-level
   - []

--- a/test/fixtures/formatting-before/fmt-3.yml
+++ b/test/fixtures/formatting-before/fmt-3.yml
@@ -1,0 +1,16 @@
+---
+dummy_map:       # eol comment
+# full line comment not indented
+  something:
+    # full line comment indented
+  # next full line comment indented
+    - or
+            # 1 full line comments over indented
+            # 2 full line comments over indented
+    - other
+
+# comment before top-level
+second_key:
+  - []
+# comment before non top-level
+  - []

--- a/test/fixtures/formatting-before/fmt-3.yml
+++ b/test/fixtures/formatting-before/fmt-3.yml
@@ -11,6 +11,8 @@ dummy_map:       # eol comment
 
 # comment before top-level
 second_key:
-  - []
+  - { } # should drop the extra space in flow map
+# comment before non top-level
+  - {}
 # comment before non top-level
   - []

--- a/test/fixtures/formatting-prettier/fmt-3.yml
+++ b/test/fixtures/formatting-prettier/fmt-3.yml
@@ -1,0 +1,16 @@
+---
+dummy_map: # eol comment
+  # full line comment not indented
+  something:
+    # full line comment indented
+    # next full line comment indented
+    - or
+      # 1 full line comments over indented
+      # 2 full line comments over indented
+    - other
+
+# comment before top-level
+second_key:
+  - []
+  # comment before non top-level
+  - []

--- a/test/fixtures/formatting-prettier/fmt-3.yml
+++ b/test/fixtures/formatting-prettier/fmt-3.yml
@@ -11,6 +11,8 @@ dummy_map: # eol comment
 
 # comment before top-level
 second_key:
-  - []
+  - {} # should drop the extra space in flow map
+  # comment before non top-level
+  - {}
   # comment before non top-level
   - []


### PR DESCRIPTION
This is probably not perfect but it indents more of the comment lines as prettier does.
Ideally, we need to peek at the next object to determine how to format the comment, but the Emitter does not have that information.
Hopefully a future release of `ruamel.yaml` will move more of the comment lines from "post" comments to "pre" comments so that the Emitter does not need to guess about what comes next.
That involves changing the parsing layer to split up the comments somehow, but it is too big a change for us to implement by extending `ruamel.yaml`.

This PR also fixes an issue where empty flow maps were written as `{ }` instead of `{}`.

- Don't dedent full line comments
- Handle full line comments more like prettier
- no space in empty flow maps and better full line comment indentation
