### PR TITLE
Configure FormattedYAML using YamllintConfig

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,6 +301,7 @@ nitpick_ignore = [
     ("py:class", "ruamel.yaml.representer.RoundTripRepresenter"),
     ("py:class", "ruamel.yaml.scalarint.ScalarInt"),
     ("py:class", "ruamel.yaml.tokens.CommentToken"),
+    ("py:class", "yamllint.config.YamlLintConfig"),
     ("py:obj", "Any"),
     ("py:obj", "ansiblelint.formatters.T"),
 ]


### PR DESCRIPTION
This makes a few of the FormattedYAML settings configurable based on the yamllint settings.
Where the yamllint setting is ambiguous (a rule is not enabled, or it allows "any"), then default to something that is (hopefully, but debatably) sane.

- move YAMLLINT_CONFIG from rules.YamllintRule to yaml_utils
- Configure FormattedYAML using YamllintConfig
