### PR TITLE
Standardize yaml quotes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
+---
 # .ansible-lint
 # exclude_paths included in this file are parsed relative to this file's location
 # and not relative to the CWD of execution. CLI arguments passed to the --exclude
@@ -5,6 +6,8 @@
 exclude_paths:
   - .cache/ # implicit unless exclude_paths is defined in config
   - .github/
+  - test/fixtures/formatting-before/
+  - test/fixtures/formatting-prettier/
 # parseable: true
 # quiet: true
 # verbosity: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ default_language_version:
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     # keep it before yamllint
-    rev: "v2.5.1"
+    rev: v2.5.1
     hooks:
       - id: prettier
         # Temporary excludes so we can gradually normalize the formatting
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: cspell
         # entry: codespell --relative
-        args: ["--relative", "--no-progress", "--no-summary"]
+        args: [--relative, --no-progress, --no-summary]
         name: Spell check with cspell
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.10.2
@@ -118,7 +118,7 @@ repos:
     hooks:
       - id: mypy
         # empty args needed in order to match mypy cli behavior
-        args: ["--strict"]
+        args: [--strict]
         additional_dependencies:
           - ansible-core
           - enrich

--- a/examples/galaxy.yml
+++ b/examples/galaxy.yml
@@ -5,11 +5,11 @@ version: 1.2.3
 authors:
   - John
 readme: ../README.md
-description: ...
+description: "..."
 dependencies:
-  "other_namespace.collection1": ">=1.0.0"
-  "other_namespace.collection2": ">=2.0.0,<3.0.0"
-  "anderson55.my_collection": "*" # note: "*" selects the highest version available
+  other_namespace.collection1: ">=1.0.0"
+  other_namespace.collection2: ">=2.0.0,<3.0.0"
+  anderson55.my_collection: "*" # note: "*" selects the highest version available
 license:
   - GPL
   - Apache

--- a/examples/playbooks/become.yml
+++ b/examples/playbooks/become.yml
@@ -5,7 +5,7 @@
     - name: clone content repository
       ansible.builtin.git:
         repo: "{{ archive_services_repo_url }}"
-        dest: "/home/www"
+        dest: /home/www
         accept_hostkey: true
         version: master
         update: false

--- a/examples/playbooks/block.yml
+++ b/examples/playbooks/block.yml
@@ -2,7 +2,7 @@
 - hosts: all
 
   pre_tasks:
-    - { import_tasks: "does-not-exist.yml" }
+    - { import_tasks: does-not-exist.yml }
 
   tasks:
     - block:

--- a/examples/playbooks/blockincludes.yml
+++ b/examples/playbooks/blockincludes.yml
@@ -10,4 +10,4 @@
             - block:
                 - ansible.builtin.include: "{{ varset }}.yml"
                 - block:
-                    - ansible.builtin.include_tasks: "tasks/directory with spaces/main.yml"
+                    - ansible.builtin.include_tasks: tasks/directory with spaces/main.yml

--- a/examples/playbooks/blockincludes2.yml
+++ b/examples/playbooks/blockincludes2.yml
@@ -10,4 +10,4 @@
       rescue:
         - ansible.builtin.include_tasks: "{{ varset }}.yml"
       always:
-        - ansible.builtin.include_tasks: "tasks/directory with spaces/main.yml"
+        - ansible.builtin.include_tasks: tasks/directory with spaces/main.yml

--- a/examples/playbooks/example.yml
+++ b/examples/playbooks/example.yml
@@ -2,8 +2,8 @@
 - hosts: webservers
 
   vars:
-    old_school: "1.2.3"
-    bracket: "and close bracket"
+    old_school: 1.2.3
+    bracket: and close bracket
 
   tasks:
     - name: unset variable

--- a/examples/playbooks/multiline-brackets-do-not-match-test.yml
+++ b/examples/playbooks/multiline-brackets-do-not-match-test.yml
@@ -10,7 +10,7 @@
     }
     - ../../../roles/pods
 
-- name: "Set Origin specific facts on localhost (for later use)"
+- name: Set Origin specific facts on localhost (for later use)
   hosts: localhost
   gather_facts: no
   tasks:

--- a/examples/playbooks/multiline-bracketsmatchtest.yml
+++ b/examples/playbooks/multiline-bracketsmatchtest.yml
@@ -10,7 +10,7 @@
     }
     - ../../../roles/pods
 
-- name: "Set Origin specific facts on localhost (for later use)"
+- name: Set Origin specific facts on localhost (for later use)
   hosts: localhost
   gather_facts: no
   tasks:

--- a/examples/playbooks/rule-no-tabs.yml
+++ b/examples/playbooks/rule-no-tabs.yml
@@ -4,8 +4,8 @@
     - name: should not trigger no-tabs rules
       ansible.builtin.lineinfile:
         path: some.txt
-        regexp: '^\t$'
-        line: 'string with \t inside'
+        regexp: ^\t$
+        line: string with \t inside
     - name: foo
       ansible.builtin.debug:
         msg: "Presence of \t should trigger no-tabs here."

--- a/examples/playbooks/syntax-error.yml
+++ b/examples/playbooks/syntax-error.yml
@@ -3,4 +3,4 @@
   hosts: localhost
   tasks:
     ansible.builtin.debug:
-      msg: "Note that `tasks` is not entered as a list."
+      msg: Note that `tasks` is not entered as a list.

--- a/examples/playbooks/task-has-name-failure.yml
+++ b/examples/playbooks/task-has-name-failure.yml
@@ -5,5 +5,5 @@
     - name:
       ansible.builtin.command: echo "empty name"
     - ansible.builtin.debug:
-        msg: "Debug without a name"
+        msg: Debug without a name
     - ansible.builtin.meta: flush_handlers

--- a/examples/playbooks/taskimports.yml
+++ b/examples/playbooks/taskimports.yml
@@ -6,6 +6,6 @@
     - import_tasks: tasks/nestedincludes.yml
     # - import_tasks: "{{ varnotset }}.yml"
     - import_tasks: "{{ varset }}"
-    - import_tasks: "tasks/directory with spaces/main.yml"
+    - import_tasks: tasks/directory with spaces/main.yml
     # Import tasks by FQCN as well to ensure they load
-    - ansible.builtin.import_tasks: "tasks/passing_task.yml"
+    - ansible.builtin.import_tasks: tasks/passing_task.yml

--- a/examples/playbooks/taskincludes.yml
+++ b/examples/playbooks/taskincludes.yml
@@ -5,6 +5,6 @@
   tasks:
     # - include_tasks: "{{ varnotset }}.yml"
     - include_tasks: "{{ varset }}.yml"
-    - include_tasks: "tasks/directory with spaces/main.yml"
+    - include_tasks: tasks/directory with spaces/main.yml
     # Include tasks by FQCN as well to ensure they load
-    - ansible.builtin.include_tasks: "tasks/passing_task.yml"
+    - ansible.builtin.include_tasks: tasks/passing_task.yml

--- a/examples/playbooks/using-bare-variables-success.yml
+++ b/examples/playbooks/using-bare-variables-success.yml
@@ -53,7 +53,7 @@
       debug:
         msg: "{{ item[0] }} - {{ item[1] }}"
       with_nested:
-        - ["foo", "bar"]
+        - [foo, bar]
         - ["1", "2", "3"]
 
     - name: with_nested loop using variable list and static
@@ -105,7 +105,7 @@
     - name: with_fileglob loop using templated pattern
       debug:
         msg: "{{ item }}"
-      with_fileglob: "foo{{ glob }}"
+      with_fileglob: foo{{ glob }}
 
     ### Testing with_together
     - name: with_together loop using variable lists

--- a/examples/playbooks/valid_with_alt_extension.yaml
+++ b/examples/playbooks/valid_with_alt_extension.yaml
@@ -3,4 +3,4 @@
 - hosts: localhost
   tasks:
     - ansible.builtin.debug: # <-- should notify about missing 'name'
-        msg: "hello!"
+        msg: hello!

--- a/examples/playbooks/var-spacing.yml
+++ b/examples/playbooks/var-spacing.yml
@@ -33,7 +33,7 @@
     - name: not a jinja variable # noqa var-spacing
       ansible.builtin.debug:
         # spell-checker: disable-next-line
-        msg: "data = ${lookup{$local_part}lsearch{/etc/aliases}}"
+        msg: data = ${lookup{$local_part}lsearch{/etc/aliases}}
     - name: JSON inside jinja is valid
       ansible.builtin.debug:
         msg: "{{ {'test': {'subtest': variable}} }}"

--- a/examples/playbooks/with-skip-tag-id.yml
+++ b/examples/playbooks/with-skip-tag-id.yml
@@ -3,5 +3,5 @@
   tasks:
   - name: trailing whitespace on this line         
     git:
-      repo: '{{ archive_services_repo_url }}'
-      dest: '/home/www'
+      repo: "{{ archive_services_repo_url }}"
+      dest: /home/www

--- a/examples/roles/dependency_in_meta/meta/main.yml
+++ b/examples/roles/dependency_in_meta/meta/main.yml
@@ -32,7 +32,7 @@ dependencies:
 
 galaxy_info:
   author: foo
-  description: "Testing meta"
+  description: Testing meta
   company: Not applicable
   license: MIT
   min_ansible_version: 2.5

--- a/examples/roles/role_for_no_same_owner/tasks/fail.yml
+++ b/examples/roles/role_for_no_same_owner/tasks/fail.yml
@@ -22,39 +22,39 @@
 - name: unarchive-bz2
   ansible.builtin.unarchive:
     src: "{{ file }}.tar.bz2"
-    dest: "dummy"
+    dest: dummy
 
 - name: unarchive delegated
   ansible.builtin.unarchive:
     src: "{{ file }}.tar.bz2"
-    dest: "dummy"
+    dest: dummy
   delegate_to: localhost
 
 - name: unarchive-gz
   ansible.builtin.unarchive:
     src: "{{ file }}.tar.gz"
-    dest: "dummy"
+    dest: dummy
 
 - name: unarchive-tar
   ansible.builtin.unarchive:
     src: "{{ file }}.tar"
-    dest: "dummy"
+    dest: dummy
 
 - name: unarchive-xz
   ansible.builtin.unarchive:
     src: "{{ file }}.tar.xz"
-    dest: "dummy"
+    dest: dummy
 
 - name: unarchive-zip
   ansible.builtin.unarchive:
     src: "{{ file }}.zip"
     dest: dummy
     extra_opts:
-      - "-X"
+      - -X
 
 - name: unarchive-zip-same-owner
   ansible.builtin.unarchive:
     src: "{{ file }}.zip"
     dest: dummy
     extra_opts:
-      - "-X"
+      - -X

--- a/examples/roles/role_for_no_same_owner/tasks/pass.yml
+++ b/examples/roles/role_for_no_same_owner/tasks/pass.yml
@@ -17,16 +17,16 @@
     src: "{{ file }}.tar.gz"
     dest: dummy
     extra_opts:
-      - "--no-same-owner"
+      - --no-same-owner
 
 - name: unarchive-remote-src
   ansible.builtin.unarchive:
     src: "{{ file }}.tar.gz"
     dest: dummy
     extra_opts:
-      - "--no-same-owner"
+      - --no-same-owner
 
 - name: unarchive-unknown-file-ending
   ansible.builtin.unarchive:
     src: "{{ file }}"
-    dest: "dummy"
+    dest: dummy

--- a/test/fixtures/skip-tags.yml
+++ b/test/fixtures/skip-tags.yml
@@ -1,4 +1,4 @@
 ---
 skip_list:
-  - "bad_tag"
+  - bad_tag
 # vim: et:sw=2:syntax=yaml:ts=2:


### PR DESCRIPTION
Using `ansible-lint --write` from #1943, this PR shows how our `FormattedYAML` dumps quotes in YAML.
