### PR TITLE
standardize yaml booleans

### DIFF
--- a/examples/playbooks/command-check-success.yml
+++ b/examples/playbooks/command-check-success.yml
@@ -13,7 +13,7 @@
 
     - name: command with changed_when
       ansible.builtin.command: echo blah
-      changed_when: False
+      changed_when: false
 
     - name: command with inline creates
       ansible.builtin.command: creates=Z echo blah
@@ -39,7 +39,7 @@
 
     - name: shell with changed_when
       shell: echo blah
-      changed_when: False
+      changed_when: false
 
     - name: shell with inline creates
       shell: creates=Z echo blah

--- a/examples/playbooks/multiline-brackets-do-not-match-test.yml
+++ b/examples/playbooks/multiline-brackets-do-not-match-test.yml
@@ -12,7 +12,7 @@
 
 - name: "Set Origin specific facts on localhost (for later use)"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Setting oo_minion_ips fact on localhost
       ansible.builtin.set_fact:

--- a/examples/playbooks/multiline-bracketsmatchtest.yml
+++ b/examples/playbooks/multiline-bracketsmatchtest.yml
@@ -12,7 +12,7 @@
 
 - name: "Set Origin specific facts on localhost (for later use)"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Setting oo_minion_ips fact on localhost
       ansible.builtin.set_fact:

--- a/examples/playbooks/skiptasks.yml
+++ b/examples/playbooks/skiptasks.yml
@@ -10,7 +10,7 @@
 
     - name: test command-instead-of-module
       ansible.builtin.command: git log
-      changed_when: False
+      changed_when: false
 
     - name: test deprecated-command-syntax
       ansible.builtin.command: creates=B chmod 644 A
@@ -38,24 +38,24 @@
     - name: test git-latest (don't warn)
       ansible.builtin.command: git log
       args:
-        warn: False
-      changed_when: False
+        warn: false
+      changed_when: false
 
     - name: test hg-latest (don't warn)
       ansible.builtin.command: chmod 644 A
       args:
-        warn: False
+        warn: false
         creates: B
 
     - name: test hg-latest (warn)
       ansible.builtin.command: chmod 644 A
       args:
-        warn: yes
+        warn: true
         creates: B
 
     - name: test git-latest (don't warn single line)
       ansible.builtin.command: warn=False chdir=/tmp/blah git log
-      changed_when: False
+      changed_when: false
 
     - name: test hg-latest (don't warn single line)
       ansible.builtin.command: warn=no creates=B chmod 644 A

--- a/examples/roles/test-role/molecule/default/include-import-role.yml
+++ b/examples/roles/test-role/molecule/default/include-import-role.yml
@@ -1,6 +1,6 @@
 ---
 - name: test
-  gather_facts: no
+  gather_facts: false
   hosts: all
   roles:
     - role: test-role

--- a/test/include-import-role.yml
+++ b/test/include-import-role.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   vars:
-    var_is_set: no
+    var_is_set: false
 
   tasks:
     - import_role:
@@ -9,7 +9,7 @@
 
 - hosts: all
   vars:
-    var_is_set: no
+    var_is_set: false
 
   tasks:
     - include_role:


### PR DESCRIPTION
Using `ansible-lint --write` from #1943, this PR shows how our `FormattedYAML` dumps booleans in YAML.
