### PR TITLE
Misc YAML formatting fixes

### DIFF
--- a/examples/playbooks/with-skip-tag-id.yml
+++ b/examples/playbooks/with-skip-tag-id.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   tasks:
-  - name: trailing whitespace on this line         
-    git:
-      repo: "{{ archive_services_repo_url }}"
-      dest: /home/www
+    - name: trailing whitespace on this line         
+      git:
+        repo: "{{ archive_services_repo_url }}"
+        dest: /home/www

--- a/examples/playbooks/with-umlaut-ä.yml
+++ b/examples/playbooks/with-umlaut-ä.yml
@@ -1,5 +1,5 @@
 ---
 - hosts:
-  - localhost
+    - localhost
   roles:
-  - name: node
+    - name: node

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -694,8 +694,11 @@ class FormattedYAML(YAML):
         """Handle known issues with ruamel.yaml dumping.
 
         Make sure there's only one newline at the end of the file.
+
         Fix the indent of full-line comments to match the indent of the next line.
         See: https://stackoverflow.com/a/71355688/1134951
+
+        Make sure null list items don't end in a space.
         """
         text = text.rstrip("\n") + "\n"
 
@@ -714,7 +717,7 @@ class FormattedYAML(YAML):
 
                 # allow some full line comments to match the previous indent
                 if i > 0 and not full_line_comments and space_length:
-                    prev = lines[i-1]
+                    prev = lines[i - 1]
                     prev_space_length = len(prev) - len(prev.lstrip())
                     if prev_space_length == space_length:
                         # if the indent matches the previous line's indent, skip it.
@@ -727,5 +730,11 @@ class FormattedYAML(YAML):
                 for index, comment in full_line_comments:
                     lines[index] = spaces + comment
                 full_line_comments.clear()
+
+            cleaned = line.strip()
+            if not cleaned.startswith("#") and cleaned.endswith("-"):
+                # got an empty list item. drop any trailing spaces.
+                lines[i] = line.rstrip() + "\n"
+
         text = "".join(lines)
         return text

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -703,13 +703,27 @@ class FormattedYAML(YAML):
         full_line_comments = []
         for i, line in enumerate(lines):
             stripped = line.lstrip()
+            if not stripped:
+                # blank line. Move on.
+                continue
+
+            space_length = len(line) - len(stripped)
+
             if stripped.startswith("#"):
                 # got a full line comment
+
+                # allow some full line comments to match the previous indent
+                if i > 0 and not full_line_comments and space_length:
+                    prev = lines[i-1]
+                    prev_space_length = len(prev) - len(prev.lstrip())
+                    if prev_space_length == space_length:
+                        # if the indent matches the previous line's indent, skip it.
+                        continue
+
                 full_line_comments.append((i, stripped))
             elif full_line_comments:
                 # end of full line comments so adjust to match indent of this line
-                non_space_length = len(stripped)
-                spaces = line[:-non_space_length]
+                spaces = " " * space_length
                 for index, comment in full_line_comments:
                     lines[index] = spaces + comment
                 full_line_comments.clear()

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -703,7 +703,7 @@ class FormattedYAML(YAML):
         text = text.rstrip("\n") + "\n"
 
         lines = text.splitlines(keepends=True)
-        full_line_comments = []
+        full_line_comments: List[Tuple[int, str]] = []
         for i, line in enumerate(lines):
             stripped = line.lstrip()
             if not stripped:
@@ -719,7 +719,10 @@ class FormattedYAML(YAML):
                 if i > 0 and not full_line_comments and space_length:
                     prev = lines[i - 1]
                     prev_space_length = len(prev) - len(prev.lstrip())
-                    if prev_space_length == space_length:
+                    is_first_line_of_string = bool(
+                        set(prev.rstrip()[-2:]).intersection({"|", ">"})
+                    )
+                    if prev_space_length == space_length or is_first_line_of_string:
                         # if the indent matches the previous line's indent, skip it.
                         continue
 

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -730,7 +730,7 @@ class FormattedYAML(YAML):
         for line in text.splitlines(True):
             # We only need to capture the preamble comments. No need to remove them.
             # lines might also include directives.
-            if line.lstrip().startswith("#"):
+            if line.lstrip().startswith("#") or line == "\n":
                 preamble_comments.append(line)
             elif line.startswith("---"):
                 break

--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -432,11 +432,13 @@ class FormattedEmitter(Emitter):
         if comment.column > self.column + 1 and not pre:
             comment.column = self.column + 1
 
-        if self._re_full_line_comment.search(value) or (
-            pre and self.indent is not None
-        ):
-            # we need to re-indent full line comments to match prettier's format
-            self._mutate_full_line_comments(comment, pre)
+        # TODO: This is not reliable. It messes up more than it fixes.
+        #       The only file it seems to work well with is the fmt-3.yml fixture.
+        # if self._re_full_line_comment.search(value) or (
+        #     pre and self.indent is not None
+        # ):
+        #     # we need to re-indent full line comments to match prettier's format
+        #     self._mutate_full_line_comments(comment, pre)
 
         return super().write_comment(comment, pre)
 

--- a/test/fixtures/formatting-after/fmt-3.yml
+++ b/test/fixtures/formatting-after/fmt-3.yml
@@ -1,18 +1,18 @@
 ---
 dummy_map: # eol comment
-# full line comment not indented
+  # full line comment not indented
   something:
     # full line comment indented
-  # next full line comment indented
+    # next full line comment indented
     - or
-            # 1 full line comments over indented
-            # 2 full line comments over indented
+      # 1 full line comments over indented
+      # 2 full line comments over indented
     - other
 
 # comment before top-level
 second_key:
   - {} # should drop the extra space in flow map
-# comment before non top-level
+  # comment before non top-level
   - {}
-# comment before non top-level
+  # comment before non top-level
   - []

--- a/test/fixtures/formatting-after/fmt-3.yml
+++ b/test/fixtures/formatting-after/fmt-3.yml
@@ -8,6 +8,9 @@ dummy_map: # eol comment
     # 1 full line comments over indented
     # 2 full line comments over indented
     - other
+    - |
+      # this is part of a string not a yaml comment
+      # also not a comment
 
 # comment before top-level
 second_key:

--- a/test/fixtures/formatting-after/fmt-3.yml
+++ b/test/fixtures/formatting-after/fmt-3.yml
@@ -1,18 +1,18 @@
 ---
 dummy_map: # eol comment
-  # full line comment not indented
+# full line comment not indented
   something:
     # full line comment indented
-    # next full line comment indented
+  # next full line comment indented
     - or
-      # 1 full line comments over indented
-      # 2 full line comments over indented
+            # 1 full line comments over indented
+            # 2 full line comments over indented
     - other
 
 # comment before top-level
 second_key:
   - {} # should drop the extra space in flow map
-  # comment before non top-level
+# comment before non top-level
   - {}
-  # comment before non top-level
+# comment before non top-level
   - []

--- a/test/fixtures/formatting-after/fmt-3.yml
+++ b/test/fixtures/formatting-after/fmt-3.yml
@@ -5,8 +5,8 @@ dummy_map: # eol comment
     # full line comment indented
     # next full line comment indented
     - or
-      # 1 full line comments over indented
-      # 2 full line comments over indented
+    # 1 full line comments over indented
+    # 2 full line comments over indented
     - other
 
 # comment before top-level

--- a/test/fixtures/formatting-before/fmt-3.yml
+++ b/test/fixtures/formatting-before/fmt-3.yml
@@ -8,6 +8,9 @@ dummy_map:       # eol comment
             # 1 full line comments over indented
             # 2 full line comments over indented
     - other
+    - |
+      # this is part of a string not a yaml comment
+      # also not a comment
 
 # comment before top-level
 second_key:

--- a/test/fixtures/formatting-prettier/fmt-3.yml
+++ b/test/fixtures/formatting-prettier/fmt-3.yml
@@ -8,6 +8,9 @@ dummy_map: # eol comment
       # 1 full line comments over indented
       # 2 full line comments over indented
     - other
+    - |
+      # this is part of a string not a yaml comment
+      # also not a comment
 
 # comment before top-level
 second_key:


### PR DESCRIPTION
Misc bits to wrap up the MVP of YAML formatting.

This replaces the full line comment indentation logic with some post-processing as recommended in https://stackoverflow.com/a/71355688/1134951

And it 
- standardizes examples indent
- Includes blank lines in yaml preamble
- Ensures that a line with a null list item does not end with a space

This is much more reliable than the previous implementation. There are still some quirks, but it is much better.