### PR TITLE
Added missing 'truthy' setting in YAMLLINT_CONFIG

### DIFF
--- a/src/ansiblelint/yaml_utils.py
+++ b/src/ansiblelint/yaml_utils.py
@@ -50,6 +50,9 @@ rules:
   # you can easily change it or disable in your .yamllint file.
   line-length:
     max: 160
+  # By default only "false" or "true" is considered truthy.
+  truthy:
+    allowed-values: ["true", "True", "false", "False", "yes", "no"]
 """
 
 


### PR DESCRIPTION
By default yamllint does not consider "yes" and "no" to be valid truthy values (only "true" or "false" is allowed by default). Since "yes" and "no" is very common in Ansible playbooks (e.g "become: yes") it should be allowed in the default yamllint config used by ansible-lint.

Alternative solution to extending the "truthy" setting would be to disable it completely but I figured just adding the missing common values is a little bit nicer.
