### PR TITLE
Better protect strings with '#' when dumping YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ src/ansiblelint/_version.py
 # Unformatted fixtures, need to be added with force as we need to exclude
 # them from being reformatted (.prettierignore is a symlink to .gitignore)
 test/fixtures/formatting-before/
-# prettier should not edit this (yet)
+# prettier should not edit this due to forcibly extra-long lines
 examples/playbooks/vars/strings.transformed.yml
 
 # other

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,6 +297,7 @@ nitpick_ignore = [
     ("py:class", "ruamel.yaml.constructor.RoundTripConstructor"),
     ("py:class", "ruamel.yaml.emitter.Emitter"),
     ("py:class", "StreamType"),  # used in Emitter's type annotation
+    ("py:class", "ruamel.yaml.emitter.ScalarAnalysis"),
     ("py:class", "ruamel.yaml.nodes.ScalarNode"),
     ("py:class", "ruamel.yaml.representer.RoundTripRepresenter"),
     ("py:class", "ruamel.yaml.scalarint.ScalarInt"),

--- a/examples/playbooks/vars/strings.transformed.yml
+++ b/examples/playbooks/vars/strings.transformed.yml
@@ -6,13 +6,13 @@ single: single # this is a comment
 single_with_double: '"single" quoted' # this is a comment
 
 single_multiline_with_octothorpe: "single over 160 char line to force wrapping. over 160 char line to force wrapping. over 160 char line to force wrapping. over 160\n\
-# this is not a comment"
+  # this is not a comment"
 
 double: double # this is a comment
 double_with_single: "'double' quoted" # this is a comment
 
 double_multiline_with_octothorpe: "double over 160 char line to force wrapping. over 160 char line to force wrapping. over 160 char line to force wrapping. over 160\n\
-# this is not a comment"
+  # this is not a comment"
 
 # this is a comment
 folded_block_scalar_with_octothorpe: >
@@ -28,11 +28,11 @@ folded_chomp_keep_block_scalar_with_octothorpe: >+
 
 # this is a comment
 literal_block_scalar_with_octothorpe: | # this is a | EOL comment
-# this is not a comment
+  # this is not a comment
 
 # this is a comment
 literal_chomp_strip_block_scalar_with_octothorpe: |- # this is a | EOL comment
-# this is not a comment
+  # this is not a comment
 
 # this is a comment
 literal_chomp_keep_block_scalar_with_octothorpe: | # this is a | EOL comment

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,8 @@ install_requires =
   packaging
   pyyaml
   rich>=9.5.1
-  ruamel.yaml >= 0.15.34
+  # The next version is planned to have breaking changes
+  ruamel.yaml >= 0.15.34, < 0.18
   # NOTE: per issue #509 0.15.34 included in debian backports
   typing-extensions; python_version < "3.8"
   wcmatch>=7.0  # MIT

--- a/src/ansiblelint/transformer.py
+++ b/src/ansiblelint/transformer.py
@@ -48,7 +48,6 @@ class Transformer:
 
     def run(self) -> None:
         """For each file, read it, execute transforms on it, then write it."""
-        yaml = FormattedYAML()
         for file, _ in self.matches_per_file.items():
             # str() convinces mypy that "text/yaml" is a valid Literal.
             # Otherwise, it thinks base_kind is one of playbook, meta, tasks, ...
@@ -62,6 +61,11 @@ class Transformer:
                 file_is_yaml = False
 
             if file_is_yaml:
+                # We need a fresh YAML() instance for each load because ruamel.yaml
+                # stores intermediate state during load which could affect loading
+                # any other files. (Based on suggestion from ruamel.yaml author)
+                yaml = FormattedYAML()
+
                 ruamel_data: Union[CommentedMap, CommentedSeq] = yaml.loads(data)
                 if not isinstance(ruamel_data, (CommentedMap, CommentedSeq)):
                     # This is an empty vars file or similar which loads as None.


### PR DESCRIPTION
I'm using a string of unicode chars (that happen to look like `#`) to make sure no string can have a line that starts with `#`. That makes sure that those lines won't be mis-identified as full line comments in post-processing.

Anthon suggested moving all full line comments so they start in column 0, but that prevented me from preserving the indentation in a few cases (that I didn't know about when I asked him).
However, doing something earlier, when information about what is and isn't a comment, was a fantastic idea. I ended up modifying the strings instead of the comments, but I'm happy with the (much more reliable) result.

So, thanks @AvdN for helping me find a great way to do this with the current version of ruamel.yaml!
