### PR TITLE
Add test case that shows how FormattedYAML breaks some strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ src/ansiblelint/_version.py
 # Unformatted fixtures, need to be added with force as we need to exclude
 # them from being reformatted (.prettierignore is a symlink to .gitignore)
 test/fixtures/formatting-before/
+# prettier should not edit this (yet)
+examples/playbooks/vars/strings.transformed.yml
 
 # other
 .DS_Store

--- a/examples/playbooks/vars/strings.transformed.yml
+++ b/examples/playbooks/vars/strings.transformed.yml
@@ -1,0 +1,39 @@
+---
+# Make sure that the Transformer does not mangle strings
+# TODO: there is a bug in ruamel.yaml that discards some EOL comments
+
+single: single # this is a comment
+single_with_double: '"single" quoted' # this is a comment
+
+single_multiline_with_octothorpe: "single over 160 char line to force wrapping. over 160 char line to force wrapping. over 160 char line to force wrapping. over 160\n\
+# this is not a comment"
+
+double: double # this is a comment
+double_with_single: "'double' quoted" # this is a comment
+
+double_multiline_with_octothorpe: "double over 160 char line to force wrapping. over 160 char line to force wrapping. over 160 char line to force wrapping. over 160\n\
+# this is not a comment"
+
+# this is a comment
+folded_block_scalar_with_octothorpe: >
+  # this is not a comment
+
+# this is a comment
+folded_chomp_strip_block_scalar_with_octothorpe: >-
+  # this is not a comment
+
+# this is a comment
+folded_chomp_keep_block_scalar_with_octothorpe: >+
+  # this is not a comment
+
+# this is a comment
+literal_block_scalar_with_octothorpe: | # this is a | EOL comment
+# this is not a comment
+
+# this is a comment
+literal_chomp_strip_block_scalar_with_octothorpe: |- # this is a | EOL comment
+# this is not a comment
+
+# this is a comment
+literal_chomp_keep_block_scalar_with_octothorpe: | # this is a | EOL comment
+  # this is not a comment

--- a/examples/playbooks/vars/strings.yml
+++ b/examples/playbooks/vars/strings.yml
@@ -1,0 +1,45 @@
+---
+# Make sure that the Transformer does not mangle strings
+# TODO: there is a bug in ruamel.yaml that discards some EOL comments
+
+single: "single" # this is a comment
+single_with_double: '"single" quoted' # this is a comment
+
+single_multiline_with_octothorpe: # this EOL comment gets lost
+  "single over 160 char line to force wrapping. over 160 char line to force wrapping. over 160 char line to force wrapping.
+  over 160
+
+  # this is not a comment"
+
+double: "double" # this is a comment
+double_with_single: "'double' quoted" # this is a comment
+
+double_multiline_with_octothorpe: # this EOL comment gets lost
+  "double over 160 char line to force wrapping. over 160 char line to force wrapping. over 160 char line to force wrapping.
+  over 160
+
+  # this is not a comment"
+
+# this is a comment
+folded_block_scalar_with_octothorpe: > # > EOL comment gets lost
+  # this is not a comment
+
+# this is a comment
+folded_chomp_strip_block_scalar_with_octothorpe: >- # > EOL comment gets lost
+  # this is not a comment
+
+# this is a comment
+folded_chomp_keep_block_scalar_with_octothorpe: >+ # > EOL comment gets lost
+  # this is not a comment
+
+# this is a comment
+literal_block_scalar_with_octothorpe: | # this is a | EOL comment
+  # this is not a comment
+
+# this is a comment
+literal_chomp_strip_block_scalar_with_octothorpe: |- # this is a | EOL comment
+  # this is not a comment
+
+# this is a comment
+literal_chomp_keep_block_scalar_with_octothorpe: |+ # this is a | EOL comment
+  # this is not a comment

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -56,9 +56,7 @@ def runner_result(
         pytest.param(
             "examples/playbooks/vars/empty_vars.yml", 0, False, id="empty_vars"
         ),
-        pytest.param(
-            "examples/playbooks/vars/strings.yml", 0, True, id="strings"
-        ),
+        pytest.param("examples/playbooks/vars/strings.yml", 0, True, id="strings"),
     ),
 )
 def test_transformer(

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -56,6 +56,9 @@ def runner_result(
         pytest.param(
             "examples/playbooks/vars/empty_vars.yml", 0, False, id="empty_vars"
         ),
+        pytest.param(
+            "examples/playbooks/vars/strings.yml", 0, True, id="strings"
+        ),
     ),
 )
 def test_transformer(


### PR DESCRIPTION
#1956 will correct the messed up `examples/vars/strings.transformed.yml` file
