### PR TITLE
packit: build SRPM in Copr

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -146,6 +146,7 @@ signoff
 skippable
 skiptasks
 skiputils
+srpm
 stylesheet
 subdir
 subelements

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,15 +17,10 @@ jobs:
   - job: copr_build
     metadata:
       targets:
-        # Unable to build `centos-stream` due to missing python3-setuptools_scm_git_archive
-        # which is part of EPEL.
-        # - centos-stream-x86_64
-        # - epel-8-x86_64
-        # Unable to build fedora-stable as it includes both 34 and 35 and on first one we do not have python3-setuptools_scm
-        # - fedora-stable
-        # - fedora-34 has no python3-build
+        # - fedora-34  # has no https://src.fedoraproject.org/rpms/python-build
         - fedora-35
-        - centos-stream-9
+        - fedora-36
+        # - centos-stream-9  # has not https://src.fedoraproject.org/rpms/python-build
     trigger: pull_request
   # - job: tests
   #   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,13 +4,15 @@ specfile_path: dist/ansible-lint.spec
 actions:
   create-archive:
     # packit.dev service does have these module pre-installed:
-    - python3 -m pip install --user build setuptools-scm
     - python3 -m build --sdist --outdir dist
     - sh -c "ls dist/ansible-lint-*.tar.gz"
   get-current-version:
     - ./tools/get-version.sh
   post-upstream-clone:
     - ./tools/update-version.sh
+srpm_build_deps:
+  - python3-build
+  - python3-setuptools_scm
 jobs:
   - job: copr_build
     metadata:
@@ -21,7 +23,9 @@ jobs:
         # - epel-8-x86_64
         # Unable to build fedora-stable as it includes both 34 and 35 and on first one we do not have python3-setuptools_scm
         # - fedora-stable
+        # - fedora-34 has no python3-build
         - fedora-35
+        - centos-stream-9
     trigger: pull_request
   # - job: tests
   #   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,7 +20,7 @@ jobs:
         # - fedora-34  # has no https://src.fedoraproject.org/rpms/python-build
         - fedora-35
         - fedora-36
-        # - centos-stream-9  # has not https://src.fedoraproject.org/rpms/python-build
+        # - centos-stream-9  # has no https://src.fedoraproject.org/rpms/python-build
     trigger: pull_request
   # - job: tests
   #   trigger: pull_request


### PR DESCRIPTION
and install dependencies from the distro instead of PyPI

Details: https://packit.dev/posts/copr-srpms/