### PR TITLE
Add MatchError.match_type to record how the error was generated

### DIFF
--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -71,6 +71,9 @@ class MatchError(ValueError):
         # we can still filter by them.
         self.tag = tag
 
+        # optional indicator on how this error was found
+        self.match_type: Optional[str] = None
+
     def __repr__(self) -> str:
         """Return a MatchError instance representation."""
         formatstr = "[{0}] ({1}) matched {2}:{3} {4}"


### PR DESCRIPTION
This PR is another step towards adding Rule Transforms.

In some cases, it is helpful for the transforms to know whether the error was generated for a task, a line, or a play. This is especially relevant when a rule uses more than one of the `match*` methods, and the Transform needs to distinguish between the different modes when fixing the issue.

This logic is in `AnsibleLintRule.create_rule()` because this is the primary method for creating MatchErrors. We don't use (or need to use) `create_rule()` when the error is for: `LoadFailingRule()`, `AnsibleSyntaxCheckRule()`, `RuntimeErrorRule()`, `AnsibleParserErrorRule()` and in some tests. These rules are not going to get Transforms, and the tests creating dummy MatchErrors don't need to know about the match_type. So, `create_rule()` is a nice central spot to annotate the MatchError without spraying that logic all over the place.