### PR TITLE
Rename prerun submodule to _mockings

### DIFF
--- a/src/ansiblelint/_mockings.py
+++ b/src/ansiblelint/_mockings.py
@@ -1,4 +1,4 @@
-"""Utilities for configuring ansible runtime environment."""
+"""Utilities for mocking ansible modules and roles."""
 import logging
 import os
 import pathlib

--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, Any, List, Tuple, Type
 from ansible_compat.runtime import Runtime
 
 from ansiblelint import formatters
+from ansiblelint._mockings import _perform_mockings
 from ansiblelint.color import console, console_stderr, render_yaml
 from ansiblelint.config import options
 from ansiblelint.errors import MatchError
-from ansiblelint.prerun import _perform_mockings
 
 if TYPE_CHECKING:
     from argparse import Namespace


### PR DESCRIPTION
This is finishing the obliteration of prerun submodule by moving the only things still used into a private module with a name that correctly indicate what it contains.