### PR TITLE
Load rule classes from any modules

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -68,6 +68,7 @@ hwcksum
 idempotency
 importlib
 iniconfig
+isclass
 isdir
 isdisjoint
 iskeyword


### PR DESCRIPTION
This change is preparing for #1977 so we can rename the module names that include rule classes. We no longer make the assumption that the module name must match that rule class name.