### PR TITLE
Remove html extension from documentation

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -46,6 +46,7 @@ delenv
 denormalize
 deps
 devel
+dirhtml
 dists
 distutils
 docstrings

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,8 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  builder: html
+  # keep dirhtml for nice URLs without .html extension
+  builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
    :alt: PyPI version
 
 .. image:: https://img.shields.io/badge/Ansible--lint-rules%20table-blue.svg
-   :target: https://ansible-lint.readthedocs.io/en/latest/default_rules.html
+   :target: https://ansible-lint.readthedocs.io/en/latest/default_rules
    :alt: Ansible-lint rules explanation
 
 .. image:: https://img.shields.io/badge/Code%20of%20Conduct-black.svg
@@ -57,7 +57,7 @@ Authors
 ansible-lint was created by `Will Thames`_ and is now maintained as part of the
 `Ansible`_ by `Red Hat`_ project.
 
-.. _Contribution guidelines: https://ansible-lint.readthedocs.io/en/latest/contributing.html
+.. _Contribution guidelines: https://ansible-lint.readthedocs.io/en/latest/contributing
 .. _Will Thames: https://github.com/willthames
 .. _Ansible: https://ansible.com
 .. _Red Hat: https://redhat.com

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,8 +24,8 @@ to create a new rule by following the steps below:
 
 * Use a short but clear class name, which must match the filename
 * Pick an unused ``id``, the first number is used to determine rule section.
-  Look at rules_ page and pick one that matches the best your new rule.
-  see which one fits best.
+  Look at :ref:`rules <default_rules>` page and pick one that matches the best
+  your new rule and ee which one fits best.
 * Include ``experimental`` tag. Any new rule must stay as
   experimental for at least two weeks until this tag is removed in next major
   release.
@@ -47,4 +47,3 @@ to create a new rule by following the steps below:
   displayed correctly in them.
 
 .. _MetaTagValidRule: https://github.com/ansible-community/ansible-lint/blob/main/src/ansiblelint/rules/meta_no_tags.py
-.. _rules: https://ansible-lint.readthedocs.io/en/latest/default_rules.html

--- a/docs/default_rules.rst
+++ b/docs/default_rules.rst
@@ -1,1 +1,3 @@
+.. _default_rules:
+
 .. ansible-lint-default-rules-list::


### PR DESCRIPTION
Makes URLs nicer by using dirhtml build instead of html. The effect
is that you will no longer see .html as part of URLs.