### PR TITLE
Address pylint  unspecified-encoding

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,4 +27,3 @@ disable =
     too-many-instance-attributes,
     too-many-return-statements,
     unused-argument,
-    unspecified-encoding,

--- a/src/ansiblelint/_mockings.py
+++ b/src/ansiblelint/_mockings.py
@@ -49,7 +49,7 @@ def _write_module_stub(
     body = ANSIBLE_MOCKED_MODULE.format(
         name=name, collection=collection, namespace=namespace
     )
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(body)
 
 

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -65,7 +65,7 @@ def load_config(config_file: str) -> Dict[Any, Any]:
         return {}
 
     try:
-        with open(config_path, "r") as stream:
+        with open(config_path, "r", encoding="utf-8") as stream:
             config = yaml.safe_load(stream)
             if not isinstance(config, dict):
                 _logger.error("Invalid configuration file %s", config_path)

--- a/src/ansiblelint/loaders.py
+++ b/src/ansiblelint/loaders.py
@@ -6,5 +6,5 @@ import yaml
 
 def yaml_from_file(filepath: str) -> Any:
     """Return a loaded YAML file."""
-    with open(filepath) as content:
+    with open(filepath, encoding="utf-8") as content:
         return yaml.load(content, Loader=yaml.FullLoader)

--- a/src/ansiblelint/testing/__init__.py
+++ b/src/ansiblelint/testing/__init__.py
@@ -52,7 +52,7 @@ class RunFromText:
         role_path = tempfile.mkdtemp(prefix="role_")
         tasks_path = os.path.join(role_path, "tasks")
         os.makedirs(tasks_path)
-        with open(os.path.join(tasks_path, "main.yml"), "w") as fh:
+        with open(os.path.join(tasks_path, "main.yml"), "w", encoding="utf-8") as fh:
             fh.write(tasks_main_text)
         results = self._call_runner(role_path)
         shutil.rmtree(role_path)
@@ -63,7 +63,7 @@ class RunFromText:
         role_path = tempfile.mkdtemp(prefix="role_")
         meta_path = os.path.join(role_path, "meta")
         os.makedirs(meta_path)
-        with open(os.path.join(meta_path, "main.yml"), "w") as fh:
+        with open(os.path.join(meta_path, "main.yml"), "w", encoding="utf-8") as fh:
             fh.write(meta_main_text)
         results = self._call_runner(role_path)
         shutil.rmtree(role_path)


### PR DESCRIPTION
It should be noted that we already had `utf-8` in multiple places and this one is adding it everywhere. We have no plans to support other encodings.