### PR TITLE
Address pylint missing-class-docstring (old)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,6 @@ disable =
     dangerous-default-value,
     duplicate-code,
     fixme,
-    missing-class-docstring,
     missing-function-docstring,
     missing-module-docstring,
     no-member,

--- a/src/ansiblelint/cli.py
+++ b/src/ansiblelint/cli.py
@@ -111,6 +111,8 @@ def get_config_path(config_file: Optional[str] = None) -> Optional[str]:
 
 
 class AbspathArgAction(argparse.Action):
+    """Argparse action to convert relative paths to absolute paths."""
+
     def __call__(
         self,
         parser: argparse.ArgumentParser,

--- a/src/ansiblelint/formatters/__init__.py
+++ b/src/ansiblelint/formatters/__init__.py
@@ -59,6 +59,8 @@ class BaseFormatter(Generic[T]):
 
 
 class Formatter(BaseFormatter):  # type: ignore
+    """Default formatter."""
+
     def format(self, match: "MatchError") -> str:
         _id = getattr(match.rule, "id", "000")
         result = f"[error_code]{_id}[/][dim]:[/] [error_title]{self.escape(match.message)}[/]"
@@ -75,6 +77,8 @@ class Formatter(BaseFormatter):  # type: ignore
 
 
 class QuietFormatter(BaseFormatter[Any]):
+    """A very brief formatter."""
+
     def format(self, match: "MatchError") -> str:
         return (
             f"[error_code]{match.rule.id}[/] "

--- a/src/ansiblelint/generate_docs.py
+++ b/src/ansiblelint/generate_docs.py
@@ -63,7 +63,10 @@ def rules_as_rich(rules: RulesCollection) -> Iterable[Table]:
         table.add_column(Markdown(rule.shortdesc))
         description = rule.description
         if rule.link:
-            description += " [(more)](%s)" % rule.link
+            description += f" [(more)]({rule.link})"
+        import inspect
+
+        description = inspect.cleandoc(description)
         table.add_row("description", Markdown(description))
         if rule.version_added:
             table.add_row("version_added", rule.version_added)

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -40,6 +40,8 @@ match_types = {
 
 
 class AnsibleLintRule(BaseRule):
+    """Base class for all ansible-lint rules."""
+
     @property
     def rule_config(self) -> Dict[str, Any]:
         return get_rule_config(self.id)
@@ -224,6 +226,8 @@ def load_plugins(directory: str) -> Iterator[AnsibleLintRule]:
 
 
 class RulesCollection:
+    """Collection of AnsibleLintRules."""
+
     def __init__(
         self,
         rulesdirs: Optional[List[str]] = None,

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -32,11 +32,11 @@ if TYPE_CHECKING:
 
 
 class CommandsInsteadOfModulesRule(AnsibleLintRule):
+    """Executing a command when there is an Ansible module is generally a bad idea."""
+
     id = "command-instead-of-module"
     shortdesc = "Using command rather than module"
-    description = (
-        "Executing a command when there is an Ansible module is generally a bad idea"
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["command-shell", "idiom"]
     version_added = "historic"

--- a/src/ansiblelint/rules/command_instead_of_shell.py
+++ b/src/ansiblelint/rules/command_instead_of_shell.py
@@ -97,13 +97,11 @@ SUCCESS_PLAY = """---
 
 
 class UseCommandInsteadOfShellRule(AnsibleLintRule):
+    """Shell should only be used when piping, redirecting or chaining commands (and Ansible would be preferred for some of those!)."""
+
     id = "command-instead-of-shell"
     shortdesc = "Use shell only when shell functionality is required"
-    description = (
-        "Shell should only be used when piping, redirecting "
-        "or chaining commands (and Ansible would be preferred "
-        "for some of those!)"
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["command-shell", "idiom"]
     version_added = "historic"

--- a/src/ansiblelint/rules/deprecated_bare_vars.py
+++ b/src/ansiblelint/rules/deprecated_bare_vars.py
@@ -31,13 +31,14 @@ if TYPE_CHECKING:
 
 
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
+    """Using bare variables is deprecated.
+
+    Update your playbooks so that the environment value uses the full variable syntax ``{{ your_variable }}``.
+    """
+
     id = "deprecated-bare-vars"
     shortdesc = "Using bare variables is deprecated"
-    description = (
-        "Using bare variables is deprecated. Update your "
-        "playbooks so that the environment value uses the full variable "
-        "syntax ``{{ your_variable }}``"
-    )
+    description = __doc__
     severity = "VERY_HIGH"
     tags = ["deprecations"]
     version_added = "historic"

--- a/src/ansiblelint/rules/deprecated_command_syntax.py
+++ b/src/ansiblelint/rules/deprecated_command_syntax.py
@@ -31,12 +31,11 @@ if TYPE_CHECKING:
 
 
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
+    """Executing a command when there are arguments to modules is generally a bad idea."""
+
     id = "deprecated-command-syntax"
     shortdesc = "Using command rather than an argument to e.g. file"
-    description = (
-        "Executing a command when there are arguments to modules "
-        "is generally a bad idea"
-    )
+    description = __doc__
     severity = "VERY_HIGH"
     tags = ["command-shell", "deprecations"]
     version_added = "historic"

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -4,9 +4,11 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class TaskNoLocalAction(AnsibleLintRule):
+    """Do not use ``local_action``, use ``delegate_to: localhost``."""
+
     id = "deprecated-local-action"
     shortdesc = "Do not use 'local_action', use 'delegate_to: localhost'"
-    description = "Do not use ``local_action``, use ``delegate_to: localhost``"
+    description = __doc__
     severity = "MEDIUM"
     tags = ["deprecations"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/deprecated_module.py
+++ b/src/ansiblelint/rules/deprecated_module.py
@@ -11,14 +11,12 @@ if TYPE_CHECKING:
 
 
 class DeprecatedModuleRule(AnsibleLintRule):
+    """These are deprecated modules, some modules are kept temporarily for backwards compatibility but usage is discouraged."""
+
     id = "deprecated-module"
     shortdesc = "Deprecated module"
-    description = (
-        "These are deprecated modules, some modules are kept "
-        "temporarily for backwards compatibility but usage is discouraged. "
-        "For more details see: "
-        "https://docs.ansible.com/ansible/latest/collections/index_module.html"
-    )
+    description = __doc__
+    link = "https://docs.ansible.com/ansible/latest/collections/index_module.html"
     severity = "HIGH"
     tags = ["deprecations"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/empty_string_compare.py
+++ b/src/ansiblelint/rules/empty_string_compare.py
@@ -15,12 +15,11 @@ if TYPE_CHECKING:
 
 
 class ComparisonToEmptyStringRule(AnsibleLintRule):
+    """Use ``when: var|length > 0`` rather than ``when: var != ""`` (or conversely ``when: var|length == 0`` rather than ``when: var == ""``)."""
+
     id = "empty-string-compare"
     shortdesc = "Don't compare to empty string"
-    description = (
-        'Use ``when: var|length > 0`` rather than ``when: var != ""`` (or '
-        'conversely ``when: var|length == 0`` rather than ``when: var == ""``)'
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["idiom", "opt-in"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/fqcn_builtins.py
+++ b/src/ansiblelint/rules/fqcn_builtins.py
@@ -80,13 +80,12 @@ builtins = [
 
 
 class FQCNBuiltinsRule(AnsibleLintRule):
+    """Check whether the long version starting with ``ansible.builtin`` is used in the playbook."""
+
     id = "fqcn-builtins"
     severity = "MEDIUM"
     shortdesc = "Use FQCN for builtin actions"
-    description = (
-        "Check whether the long version starting with ``ansible.builtin`` "
-        "is used in the playbook"
-    )
+    description = __doc__
     tags = ["formatting"]
 
     def matchtask(

--- a/src/ansiblelint/rules/git_latest.py
+++ b/src/ansiblelint/rules/git_latest.py
@@ -29,12 +29,11 @@ if TYPE_CHECKING:
 
 
 class GitHasVersionRule(AnsibleLintRule):
+    """All version control checkouts must point to an explicit commit or tag, not just ``latest``."""
+
     id = "git-latest"
     shortdesc = "Git checkouts must contain explicit version"
-    description = (
-        "All version control checkouts must point to "
-        "an explicit commit or tag, not just ``latest``"
-    )
+    description = __doc__
     severity = "MEDIUM"
     tags = ["idempotency"]
     version_added = "historic"

--- a/src/ansiblelint/rules/hg_latest.py
+++ b/src/ansiblelint/rules/hg_latest.py
@@ -29,12 +29,11 @@ if TYPE_CHECKING:
 
 
 class MercurialHasRevisionRule(AnsibleLintRule):
+    """All version control checkouts must point to an explicit commit or tag, not just ``latest``."""
+
     id = "hg-latest"
     shortdesc = "Mercurial checkouts must contain explicit revision"
-    description = (
-        "All version control checkouts must point to "
-        "an explicit commit or tag, not just ``latest``"
-    )
+    description = __doc__
     severity = "MEDIUM"
     tags = ["idempotency"]
     version_added = "historic"

--- a/src/ansiblelint/rules/inline_env_var.py
+++ b/src/ansiblelint/rules/inline_env_var.py
@@ -30,12 +30,11 @@ if TYPE_CHECKING:
 
 
 class EnvVarsInCommandRule(AnsibleLintRule):
+    """Use ``environment:`` to set environment variables or use ``shell`` module which accepts both."""
+
     id = "inline-env-var"
     shortdesc = "Command module does not accept setting environment variables inline"
-    description = (
-        "Use ``environment:`` to set environment variables "
-        "or use ``shell`` module which accepts both"
-    )
+    description = __doc__
     severity = "VERY_HIGH"
     tags = ["command-shell", "idiom"]
     version_added = "historic"

--- a/src/ansiblelint/rules/literal_compare.py
+++ b/src/ansiblelint/rules/literal_compare.py
@@ -14,12 +14,11 @@ if TYPE_CHECKING:
 
 
 class ComparisonToLiteralBoolRule(AnsibleLintRule):
+    """Use ``when: var`` rather than ``when: var == True`` (or conversely ``when: not var``)."""
+
     id = "literal-compare"
     shortdesc = "Don't compare to literal True/False"
-    description = (
-        "Use ``when: var`` rather than ``when: var == True`` "
-        "(or conversely ``when: not var``)"
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["idiom"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/meta_incorrect.py
+++ b/src/ansiblelint/rules/meta_incorrect.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 
 class MetaChangeFromDefaultRule(AnsibleLintRule):
+    """meta/main.yml default values should be changed."""
+
     id = "meta-incorrect"
     shortdesc = "meta/main.yml default values should be changed"
     field_defaults = [
@@ -23,7 +25,7 @@ class MetaChangeFromDefaultRule(AnsibleLintRule):
         ("license", "license (GPLv2, CC-BY, etc)"),
         ("license", "license (GPL-2.0-or-later, MIT, etc)"),
     ]
-    description = "meta/main.yml default values should be changed for: ``{}``".format(
+    description = __doc__ + "Still using defaults: ``{}``".format(
         ", ".join(f[0] for f in field_defaults)
     )
     severity = "HIGH"

--- a/src/ansiblelint/rules/meta_no_info.py
+++ b/src/ansiblelint/rules/meta_no_info.py
@@ -55,11 +55,13 @@ def _galaxy_info_errors_itr(
 
 
 class MetaMainHasInfoRule(AnsibleLintRule):
+    """meta/main.yml should contain: author, description, license, min_ansible_version, platforms."""
+
     id = "meta-no-info"
     shortdesc = "meta/main.yml should contain relevant info"
     str_info = META_STR_INFO
     info = META_INFO
-    description = "meta/main.yml should contain: ``{}``".format(", ".join(info))
+    description = __doc__
     severity = "HIGH"
     tags = ["metadata"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/meta_no_tags.py
+++ b/src/ansiblelint/rules/meta_no_tags.py
@@ -15,12 +15,11 @@ if TYPE_CHECKING:
 
 
 class MetaTagValidRule(AnsibleLintRule):
+    """Tags must contain lowercase letters and digits only, and ``galaxy_tags`` is expected to be a list."""
+
     id = "meta-no-tags"
     shortdesc = "Tags must contain lowercase letters and digits only"
-    description = (
-        "Tags must contain lowercase letters and digits only, "
-        "and ``galaxy_tags`` is expected to be a list"
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["metadata"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/meta_video_links.py
+++ b/src/ansiblelint/rules/meta_video_links.py
@@ -15,13 +15,11 @@ if TYPE_CHECKING:
 
 
 class MetaVideoLinksRule(AnsibleLintRule):
+    """Items in ``video_links`` in meta/main.yml should be dictionaries, and contain only keys ``url`` and ``title``, and have a shared link from a supported provider."""
+
     id = "meta-video-links"
     shortdesc = "meta/main.yml video_links should be formatted correctly"
-    description = (
-        "Items in ``video_links`` in meta/main.yml should be "
-        "dictionaries, and contain only keys ``url`` and ``title``, "
-        "and have a shared link from a supported provider"
-    )
+    description = __doc__
     severity = "LOW"
     tags = ["metadata"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/no_changed_when.py
+++ b/src/ansiblelint/rules/no_changed_when.py
@@ -30,32 +30,30 @@ if TYPE_CHECKING:
 
 
 class CommandHasChangesCheckRule(AnsibleLintRule):
+    """Tasks should tell Ansible when to return ``changed``, unless the task only reads information. To do this, set ``changed_when``, use the ``creates`` or ``removes`` argument, or use ``when`` to run the task only if another check has a particular result.
+
+            For example, this task registers the ``shell`` output and uses the return code
+            to define when the task has changed.
+
+            .. code:: yaml
+
+                - name: handle shell output with return code
+                  ansible.builtin.shell: cat {{ my_file|quote }}
+                  register: my_output
+                  changed_when: my_output.rc != 0
+
+            The following example will trigger the rule since the task does not
+            handle the output of the ``command``.
+
+    .. code:: yaml
+
+        - name: does not handle any output or return codes
+            ansible.builtin.command: cat {{ my_file|quote }}
+    """
+
     id = "no-changed-when"
     shortdesc = "Commands should not change things if nothing needs doing"
-    description = """
-Tasks should tell Ansible when to return ``changed``, unless the task only reads
-information. To do this, set ``changed_when``, use the ``creates`` or
-``removes`` argument, or use ``when`` to run the task only if another check has
-a particular result.
-
-For example, this task registers the ``shell`` output and uses the return code
-to define when the task has changed.
-
-.. code:: yaml
-
-    - name: handle shell output with return code
-      ansible.builtin.shell: cat {{ my_file|quote }}
-      register: my_output
-      changed_when: my_output.rc != 0
-
-The following example will trigger the rule since the task does not
-handle the output of the ``command``.
-
-.. code:: yaml
-
-    - name: does not handle any output or return codes
-      ansible.builtin.command: cat {{ my_file|quote }}
-    """
+    description = __doc__
     severity = "HIGH"
     tags = ["command-shell", "idempotency"]
     version_added = "historic"

--- a/src/ansiblelint/rules/no_handler.py
+++ b/src/ansiblelint/rules/no_handler.py
@@ -48,13 +48,14 @@ def _changed_in_when(item: str) -> bool:
 
 
 class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
+    """If a task has a ``when: result.changed`` setting, it is effectively acting as a handler.
+
+    You could use notify and move that task to handlers.
+    """
+
     id = "no-handler"
     shortdesc = "Tasks that run when changed should likely be handlers"
-    description = (
-        "If a task has a ``when: result.changed`` setting, it is effectively "
-        "acting as a handler. You could use notify and move that task to "
-        "handlers."
-    )
+    description = __doc__
     link = "https://docs.ansible.com/ansible/latest/user_guide/playbooks_handlers.html"
     severity = "MEDIUM"
     tags = ["idiom"]

--- a/src/ansiblelint/rules/no_jinja_nesting.py
+++ b/src/ansiblelint/rules/no_jinja_nesting.py
@@ -33,14 +33,18 @@ if TYPE_CHECKING:
 
 
 class NestedJinjaRule(AnsibleLintRule):
+    """There should not be any nested jinja pattern.
+
+    Example (bad): ``{{ list_one + {{ list_two | max }} }}``.
+
+    Example (good): ``{{ list_one + max(list_two) }}``.
+
+    Example (allowed): ``--format='{{'{{'}}.Size{{'}}'}}'``.
+    """
+
     id = "no-jinja-nesting"
     shortdesc = "Nested jinja pattern"
-    description = (
-        "There should not be any nested jinja pattern. "
-        "Example (bad): ``{{ list_one + {{ list_two | max }} }}``, "
-        "Example (good): ``{{ list_one + max(list_two) }}``, "
-        "Example (allowed): ``--format='{{'{{'}}.Size{{'}}'}}'``"
-    )
+    description = __doc__
     severity = "VERY_HIGH"
     tags = ["formatting"]
     version_added = "v4.3.0"

--- a/src/ansiblelint/rules/no_jinja_when.py
+++ b/src/ansiblelint/rules/no_jinja_when.py
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
 
 
 class NoFormattingInWhenRule(AnsibleLintRule):
+    """``when`` is a raw Jinja2 expression, remove redundant {{ }} from variable(s)."""
+
     id = "no-jinja-when"
     shortdesc = "No Jinja2 in when"
-    description = (
-        "``when`` is a raw Jinja2 expression, remove redundant {{ }} from variable(s)."
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["deprecations"]
     version_added = "historic"

--- a/src/ansiblelint/rules/no_relative_paths.py
+++ b/src/ansiblelint/rules/no_relative_paths.py
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
 
 
 class RoleRelativePath(AnsibleLintRule):
+    """``copy`` and ``template`` do not need to use relative path for ``src``."""
+
     id = "no-relative-paths"
     shortdesc = "Doesn't need a relative path in role"
-    description = (
-        "``copy`` and ``template`` do not need to use relative path for ``src``"
-    )
+    description = __doc__
     severity = "HIGH"
     tags = ["idiom"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/no_same_owner.py
+++ b/src/ansiblelint/rules/no_same_owner.py
@@ -10,19 +10,17 @@ from ansiblelint.utils import LINE_NUMBER_KEY
 
 
 class NoSameOwnerRule(AnsibleLintRule):
+    """Optional rule that highlights dangers of assuming that user/group on the remote machines may not exist on ansible controller or vice versa.
+
+    Owner and group should not be preserved when transferring files between them.
+
+    This rule is not enabled by default and was inspired by Zuul execution policy.
+    """
 
     id = "no-same-owner"
     shortdesc = "Owner should not be kept between different hosts"
-    description = """
-Optional rule that highlights dangers of assuming that user/group on the remote
-machines may not exist on ansible controller or vice versa. Owner and group
-should not be preserved when transferring files between them.
-
-This rule is not enabled by default and was inspired by Zuul execution policy.
-See:
-https://zuul-ci.org/docs/zuul-jobs/policy.html\
-#preservation-of-owner-between-executor-and-remote
-"""
+    description = __doc__
+    link = "https://zuul-ci.org/docs/zuul-jobs/policy.html#preservation-of-owner-between-executor-and-remote"
     severity = "LOW"
     tags = ["opt-in"]
 

--- a/src/ansiblelint/rules/no_tabs.py
+++ b/src/ansiblelint/rules/no_tabs.py
@@ -13,9 +13,11 @@ if TYPE_CHECKING:
 
 
 class NoTabsRule(AnsibleLintRule):
+    """Tabs can cause unexpected display issues, use spaces."""
+
     id = "no-tabs"
     shortdesc = "Most files should not contain tabs"
-    description = "Tabs can cause unexpected display issues, use spaces"
+    description = __doc__
     severity = "LOW"
     tags = ["formatting"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/package_latest.py
+++ b/src/ansiblelint/rules/package_latest.py
@@ -29,11 +29,11 @@ if TYPE_CHECKING:
 
 
 class PackageIsNotLatestRule(AnsibleLintRule):
+    """Package installs should use ``state=present`` with or without a version."""
+
     id = "package-latest"
     shortdesc = "Package installs should not use latest"
-    description = (
-        "Package installs should use ``state=present`` with or without a version"
-    )
+    description = __doc__
     severity = "VERY_LOW"
     tags = ["idempotency"]
     version_added = "historic"

--- a/src/ansiblelint/rules/partial_become.py
+++ b/src/ansiblelint/rules/partial_become.py
@@ -86,9 +86,11 @@ def _become_user_without_become(becomeuserabove: bool, data: "odict[str, Any]") 
 
 
 class BecomeUserWithoutBecomeRule(AnsibleLintRule):
+    """``become_user`` without ``become`` will not actually change user."""
+
     id = "partial-become"
     shortdesc = "become_user requires become to work as expected"
-    description = "``become_user`` without ``become`` will not actually change user"
+    description = __doc__
     severity = "VERY_HIGH"
     tags = ["unpredictability"]
     version_added = "historic"

--- a/src/ansiblelint/rules/playbook_extension.py
+++ b/src/ansiblelint/rules/playbook_extension.py
@@ -10,9 +10,11 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class PlaybookExtension(AnsibleLintRule):
+    """Playbooks should have the ".yml" or ".yaml" extension."""
+
     id = "playbook-extension"
     shortdesc = 'Use ".yml" or ".yaml" playbook extension'
-    description = 'Playbooks should have the ".yml" or ".yaml" extension'
+    description = __doc__
     severity = "MEDIUM"
     tags = ["formatting"]
     done: List[str] = []

--- a/src/ansiblelint/rules/risky_file_permissions.py
+++ b/src/ansiblelint/rules/risky_file_permissions.py
@@ -66,16 +66,16 @@ _MODULES_WITH_CREATE: Dict[str, bool] = {
 
 
 class MissingFilePermissionsRule(AnsibleLintRule):
+    """Missing or unsupported mode parameter can cause unexpected file permissions based on version of Ansible being used."""
+
     id = "risky-file-permissions"
     shortdesc = "File permissions unset or incorrect"
-    description = (
-        "Missing or unsupported mode parameter can cause unexpected file "
-        "permissions based "
-        "on version of Ansible being used. Be explicit, like ``mode: 0644`` to "
+    description = __doc__ + (
+        " Be explicit, like ``mode: 0644`` to "
         "avoid hitting this rule. Special ``preserve`` value is accepted "
-        f"only by {', '.join(_modules_with_preserve)} modules. "
-        "See https://github.com/ansible/ansible/issues/71200"
+        f"only by {', '.join(_modules_with_preserve)} modules."
     )
+    link = "https://github.com/ansible/ansible/issues/71200"
     severity = "VERY_HIGH"
     tags = ["unpredictability", "experimental"]
     version_added = "v4.3.0"

--- a/src/ansiblelint/rules/risky_octal.py
+++ b/src/ansiblelint/rules/risky_octal.py
@@ -29,13 +29,12 @@ if TYPE_CHECKING:
 
 
 class OctalPermissionsRule(AnsibleLintRule):
+    """Numeric file permissions without leading zero can behave in unexpected ways."""
+
     id = "risky-octal"
     shortdesc = "Octal file permissions must contain leading zero or be a string"
-    description = (
-        "Numeric file permissions without leading zero can behave "
-        "in unexpected ways. See "
-        "https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html"
-    )
+    description = __doc__
+    link = "https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html"
     severity = "VERY_HIGH"
     tags = ["formatting"]
     version_added = "historic"

--- a/src/ansiblelint/rules/risky_shell_pipe.py
+++ b/src/ansiblelint/rules/risky_shell_pipe.py
@@ -11,16 +11,15 @@ if TYPE_CHECKING:
 
 
 class ShellWithoutPipefail(AnsibleLintRule):
+    """Without the pipefail option set, a shell command that implements a pipeline can fail and still return 0.
+
+    If any part of the pipeline other than the terminal command fails, the whole pipeline will still return 0, which may
+    be considered a success by Ansible. Pipefail is available in the bash shell.
+    """
+
     id = "risky-shell-pipe"
     shortdesc = "Shells that use pipes should set the pipefail option"
-    description = (
-        "Without the pipefail option set, a shell command that "
-        "implements a pipeline can fail and still return 0. If "
-        "any part of the pipeline other than the terminal command "
-        "fails, the whole pipeline will still return 0, which may "
-        "be considered a success by Ansible. "
-        "Pipefail is available in the bash shell."
-    )
+    description = __doc__
     severity = "MEDIUM"
     tags = ["command-shell"]
     version_added = "v4.1.0"

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -39,14 +39,12 @@ def _remove_prefix(text: str, prefix: str) -> str:
 
 
 class RoleNames(AnsibleLintRule):
+    """Role names are now limited to contain only lowercase alphanumeric characters, plus '_' and start with an alpha character."""
+
     id = "role-name"
     shortdesc = "Role name {0} does not match ``%s`` pattern" % ROLE_NAME_REGEX
-    description = (
-        "Role names are now limited to contain only lowercase alphanumeric "
-        "characters, plus '_' and start with an alpha character. See "
-        "`developing collections <https://docs.ansible.com/ansible/devel/dev_guide/"
-        "developing_collections_structure.html#roles-directory>`_"
-    )
+    description = __doc__
+    link = "https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_structure.html#roles-directory"
     severity = "HIGH"
     done: List[str] = []  # already noticed roles list
     tags = ["deprecations", "metadata"]

--- a/src/ansiblelint/rules/unnamed_task.py
+++ b/src/ansiblelint/rules/unnamed_task.py
@@ -29,12 +29,11 @@ if TYPE_CHECKING:
 
 
 class TaskHasNameRule(AnsibleLintRule):
+    """All tasks should have a distinct name for readability and for ``--start-at-task`` to work."""
+
     id = "unnamed-task"
     shortdesc = "All tasks should be named"
-    description = (
-        "All tasks should have a distinct name for readability "
-        "and for ``--start-at-task`` to work"
-    )
+    description = __doc__
     severity = "MEDIUM"
     tags = ["idiom"]
     version_added = "historic"

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -36,10 +36,12 @@ def is_property(k: str) -> bool:
 
 
 class VariableNamingRule(AnsibleLintRule):
+    """All variables should be named using only lowercase and underscores."""
+
     id = "var-naming"
     base_msg = "All variables should be named using only lowercase and underscores"
     shortdesc = base_msg
-    description = "All variables should be named using only lowercase and underscores"
+    description = __doc__
     severity = "MEDIUM"
     tags = ["idiom", "experimental"]
     version_added = "v5.0.10"

--- a/src/ansiblelint/rules/var_spacing.py
+++ b/src/ansiblelint/rules/var_spacing.py
@@ -11,10 +11,12 @@ from ansiblelint.yaml_utils import nested_items_path
 
 
 class VariableHasSpacesRule(AnsibleLintRule):
+    """Variables should have spaces before and after: ``{{ var_name }}``."""
+
     id = "var-spacing"
     base_msg = "Variables should have spaces before and after: "
     shortdesc = base_msg + " {{ var_name }}"
-    description = "Variables should have spaces before and after: ``{{ var_name }}``"
+    description = __doc__
     severity = "LOW"
     tags = ["formatting"]
     version_added = "v4.0.0"

--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -13,21 +13,20 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-DESCRIPTION = """\
-Rule violations reported by YamlLint when this is installed.
-
-You can fully disable all of them by adding 'yaml' to the 'skip_list'.
-
-Specific tag identifiers that are printed at the end of rule name,
-like 'trailing-spaces' or 'indentation' can also be be skipped, allowing
-you to have a more fine control.
-"""
-
 
 class YamllintRule(AnsibleLintRule):
+    """Rule violations reported by YamlLint when this is installed.
+
+    You can fully disable all of them by adding 'yaml' to the 'skip_list'.
+
+    Specific tag identifiers that are printed at the end of rule name,
+    like 'trailing-spaces' or 'indentation' can also be be skipped, allowing
+    you to have a more fine control.
+    """
+
     id = "yaml"
     shortdesc = "Violations reported by yamllint"
-    description = DESCRIPTION
+    description = __doc__
     severity = "VERY_LOW"
     tags = ["formatting", "yaml"]
     version_added = "v5.0.0"

--- a/test/rules/fixtures/ematcher.py
+++ b/test/rules/fixtures/ematcher.py
@@ -2,10 +2,10 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class EMatcherRule(AnsibleLintRule):
+    """This is a test custom rule that looks for lines containing BANNED string."""
+
     id = "TEST0001"
-    description = (
-        "This is a test custom rule that looks for lines " + "containing BANNED string"
-    )
+    description = __doc__
     shortdesc = "BANNED string found"
     tags = ["fake", "dummy", "test1"]
 

--- a/test/rules/fixtures/unset_variable_matcher.py
+++ b/test/rules/fixtures/unset_variable_matcher.py
@@ -2,12 +2,11 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class UnsetVariableMatcherRule(AnsibleLintRule):
+    """This is a test rule that looks for lines post templating that still contain {{."""
+
     id = "TEST0002"
     shortdesc = "Line contains untemplated variable"
-    description = (
-        "This is a test rule that looks for lines "
-        + "post templating that still contain {{"
-    )
+    description = __doc__
     tags = ["fake", "dummy", "test2"]
 
     def match(self, line: str) -> bool:

--- a/test/test_matcherrror.py
+++ b/test/test_matcherrror.py
@@ -89,6 +89,8 @@ def test_matcherror_invalid() -> None:
     ),
 )
 class TestMatchErrorCompare:
+    """Tests for MatchError comparison."""
+
     @staticmethod
     def test_match_error_less_than(
         left_match_error: MatchError, right_match_error: MatchError

--- a/test/test_with_skip_tagid.py
+++ b/test/test_with_skip_tagid.py
@@ -1,3 +1,4 @@
+"""Tests related to skipping rules."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.yaml import YamllintRule
 from ansiblelint.runner import Runner


### PR DESCRIPTION
Most of classes without a docstring were the rules and for these we
moved the description into the docstring.

This change needs extra attention regarding on how the documentation
is built, so we do not mess its rendering.