### PR TITLE
Changed rules to use docstring as shortdesc

### DIFF
--- a/docs/custom-rules.rst
+++ b/docs/custom-rules.rst
@@ -32,9 +32,9 @@ An example rule using ``match`` is:
     from ansiblelint.rules import AnsibleLintRule
 
     class DeprecatedVariableRule(AnsibleLintRule):
+        """Deprecated variable declarations."""
 
         id = 'EXAMPLE002'
-        shortdesc = 'Deprecated variable declarations'
         description = 'Check for lines that have old style ${var} ' + \
                       'declarations'
         tags = { 'deprecations' }
@@ -57,8 +57,9 @@ An example rule using ``matchtask`` is:
         from ansiblelint.file_utils import Lintable
 
     class TaskHasTag(AnsibleLintRule):
+        """Tasks must have tag."""
+
         id = 'EXAMPLE001'
-        shortdesc = 'Tasks must have tag'
         description = 'Tasks must have tag'
         tags = ['productivity']
 

--- a/examples/rules/task_has_tag.py
+++ b/examples/rules/task_has_tag.py
@@ -13,7 +13,6 @@ class TaskHasTag(AnsibleLintRule):
     """Tasks must have tag."""
 
     id = "EXAMPLE001"
-    shortdesc = "Tasks must have tag"
     description = "Tasks must have tag"
     tags = ["productivity", "tags"]
 

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -18,13 +18,17 @@ class BaseRule:
 
     id: str = ""
     tags: List[str] = []
-    shortdesc: str = ""
     description: str = ""
     version_added: str = ""
     severity: str = ""
     link: str = ""
     has_dynamic_tags: bool = False
     needs_raw_task: bool = False
+
+    @property
+    def shortdesc(self) -> str:
+        """Return the short description of the rule, basically the docstring."""
+        return self.__doc__ or ""
 
     def getmatches(self, file: "Lintable") -> List["MatchError"]:
         """Return all matches while ignoring exceptions."""
@@ -94,10 +98,9 @@ class BaseRule:
 
 
 class RuntimeErrorRule(BaseRule):
-    """Used to identify errors."""
+    """Unexpected internal error."""
 
     id = "internal-error"
-    shortdesc = "Unexpected internal error"
     description = (
         "This error can be caused by internal bugs but also by "
         "custom rules. Instead of just stopping linter we generate the errors and "
@@ -110,10 +113,9 @@ class RuntimeErrorRule(BaseRule):
 
 
 class AnsibleParserErrorRule(BaseRule):
-    """Used to mark errors received from Ansible."""
+    """AnsibleParserError."""
 
     id = "parser-error"
-    shortdesc = "AnsibleParserError"
     description = "Ansible parser fails; this usually indicates an invalid file."
     severity = "VERY_HIGH"
     tags = ["core"]
@@ -121,10 +123,9 @@ class AnsibleParserErrorRule(BaseRule):
 
 
 class LoadingFailureRule(BaseRule):
-    """File loading failure."""
+    """Failed to load or parse file."""
 
     id = "load-failure"
-    shortdesc = "Failed to load or parse file"
     description = "Linter failed to process a YAML file, possible not an Ansible file."
     severity = "VERY_HIGH"
     tags = ["core"]

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -32,8 +32,9 @@ if TYPE_CHECKING:
 
 
 class CommandsInsteadOfModulesRule(AnsibleLintRule):
+    """Using command rather than module."""
+
     id = "command-instead-of-module"
-    shortdesc = "Using command rather than module"
     description = (
         "Executing a command when there is an Ansible module is generally a bad idea"
     )

--- a/src/ansiblelint/rules/command_instead_of_shell.py
+++ b/src/ansiblelint/rules/command_instead_of_shell.py
@@ -97,8 +97,9 @@ SUCCESS_PLAY = """---
 
 
 class UseCommandInsteadOfShellRule(AnsibleLintRule):
+    """Use shell only when shell functionality is required."""
+
     id = "command-instead-of-shell"
-    shortdesc = "Use shell only when shell functionality is required"
     description = (
         "Shell should only be used when piping, redirecting "
         "or chaining commands (and Ansible would be preferred "

--- a/src/ansiblelint/rules/deprecated_bare_vars.py
+++ b/src/ansiblelint/rules/deprecated_bare_vars.py
@@ -31,8 +31,9 @@ if TYPE_CHECKING:
 
 
 class UsingBareVariablesIsDeprecatedRule(AnsibleLintRule):
+    """Using bare variables is deprecated."""
+
     id = "deprecated-bare-vars"
-    shortdesc = "Using bare variables is deprecated"
     description = (
         "Using bare variables is deprecated. Update your "
         "playbooks so that the environment value uses the full variable "

--- a/src/ansiblelint/rules/deprecated_command_syntax.py
+++ b/src/ansiblelint/rules/deprecated_command_syntax.py
@@ -31,8 +31,9 @@ if TYPE_CHECKING:
 
 
 class CommandsInsteadOfArgumentsRule(AnsibleLintRule):
+    """Using command rather than an argument to e.g. file."""
+
     id = "deprecated-command-syntax"
-    shortdesc = "Using command rather than an argument to e.g. file"
     description = (
         "Executing a command when there are arguments to modules "
         "is generally a bad idea"

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -4,8 +4,9 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class TaskNoLocalAction(AnsibleLintRule):
+    """Do not use 'local_action', use 'delegate_to: localhost'."""
+
     id = "deprecated-local-action"
-    shortdesc = "Do not use 'local_action', use 'delegate_to: localhost'"
     description = "Do not use ``local_action``, use ``delegate_to: localhost``"
     severity = "MEDIUM"
     tags = ["deprecations"]

--- a/src/ansiblelint/rules/deprecated_module.py
+++ b/src/ansiblelint/rules/deprecated_module.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
 
 
 class DeprecatedModuleRule(AnsibleLintRule):
+    """Deprecated module."""
+
     id = "deprecated-module"
-    shortdesc = "Deprecated module"
     description = (
         "These are deprecated modules, some modules are kept "
         "temporarily for backwards compatibility but usage is discouraged. "

--- a/src/ansiblelint/rules/empty_string_compare.py
+++ b/src/ansiblelint/rules/empty_string_compare.py
@@ -15,8 +15,9 @@ if TYPE_CHECKING:
 
 
 class ComparisonToEmptyStringRule(AnsibleLintRule):
+    """Don't compare to empty string."""
+
     id = "empty-string-compare"
-    shortdesc = "Don't compare to empty string"
     description = (
         'Use ``when: var|length > 0`` rather than ``when: var != ""`` (or '
         'conversely ``when: var|length == 0`` rather than ``when: var == ""``)'
@@ -83,7 +84,7 @@ if "pytest" in sys.modules:
         results = rule_runner.run_playbook(FAIL_PLAY)
         assert len(results) == 2
         for result in results:
-            assert result.message == ComparisonToEmptyStringRule.shortdesc
+            assert result.message == ComparisonToEmptyStringRule().shortdesc
 
     @pytest.mark.parametrize(
         "rule_runner", (ComparisonToEmptyStringRule,), indirect=["rule_runner"]

--- a/src/ansiblelint/rules/fqcn_builtins.py
+++ b/src/ansiblelint/rules/fqcn_builtins.py
@@ -80,9 +80,10 @@ builtins = [
 
 
 class FQCNBuiltinsRule(AnsibleLintRule):
+    """Use FQCN for builtin actions."""
+
     id = "fqcn-builtins"
     severity = "MEDIUM"
-    shortdesc = "Use FQCN for builtin actions"
     description = (
         "Check whether the long version starting with ``ansible.builtin`` "
         "is used in the playbook"
@@ -124,7 +125,7 @@ if "pytest" in sys.modules:
         results = rule_runner.run_playbook(FAIL_PLAY)
         assert len(results) == 1
         for result in results:
-            assert result.message == FQCNBuiltinsRule.shortdesc
+            assert result.message == FQCNBuiltinsRule().shortdesc
 
     @pytest.mark.parametrize(
         "rule_runner", (FQCNBuiltinsRule,), indirect=["rule_runner"]

--- a/src/ansiblelint/rules/git_latest.py
+++ b/src/ansiblelint/rules/git_latest.py
@@ -29,8 +29,9 @@ if TYPE_CHECKING:
 
 
 class GitHasVersionRule(AnsibleLintRule):
+    """Git checkouts must contain explicit version."""
+
     id = "git-latest"
-    shortdesc = "Git checkouts must contain explicit version"
     description = (
         "All version control checkouts must point to "
         "an explicit commit or tag, not just ``latest``"

--- a/src/ansiblelint/rules/hg_latest.py
+++ b/src/ansiblelint/rules/hg_latest.py
@@ -29,8 +29,9 @@ if TYPE_CHECKING:
 
 
 class MercurialHasRevisionRule(AnsibleLintRule):
+    """Mercurial checkouts must contain explicit revision."""
+
     id = "hg-latest"
-    shortdesc = "Mercurial checkouts must contain explicit revision"
     description = (
         "All version control checkouts must point to "
         "an explicit commit or tag, not just ``latest``"

--- a/src/ansiblelint/rules/ignore_errors.py
+++ b/src/ansiblelint/rules/ignore_errors.py
@@ -11,12 +11,9 @@ if TYPE_CHECKING:
 
 
 class IgnoreErrorsRule(AnsibleLintRule):
-    """Describe and test the IgnoreErrorsRule."""
+    """Use failed_when and specify error conditions instead of using ignore_errors."""
 
     id = "ignore-errors"
-    shortdesc = (
-        "Use failed_when and specify error conditions instead of using ignore_errors"
-    )
     description = (
         "Instead of ignoring all errors, ignore the errors only when using ``{{ ansible_check_mode }}``, "
         "register the errors using ``register``, "

--- a/src/ansiblelint/rules/inline_env_var.py
+++ b/src/ansiblelint/rules/inline_env_var.py
@@ -30,8 +30,9 @@ if TYPE_CHECKING:
 
 
 class EnvVarsInCommandRule(AnsibleLintRule):
+    """Command module does not accept setting environment variables inline."""
+
     id = "inline-env-var"
-    shortdesc = "Command module does not accept setting environment variables inline"
     description = (
         "Use ``environment:`` to set environment variables "
         "or use ``shell`` module which accepts both"

--- a/src/ansiblelint/rules/literal_compare.py
+++ b/src/ansiblelint/rules/literal_compare.py
@@ -14,8 +14,9 @@ if TYPE_CHECKING:
 
 
 class ComparisonToLiteralBoolRule(AnsibleLintRule):
+    """Don't compare to literal True/False."""
+
     id = "literal-compare"
-    shortdesc = "Don't compare to literal True/False"
     description = (
         "Use ``when: var`` rather than ``when: var == True`` "
         "(or conversely ``when: not var``)"

--- a/src/ansiblelint/rules/meta_incorrect.py
+++ b/src/ansiblelint/rules/meta_incorrect.py
@@ -14,8 +14,9 @@ if TYPE_CHECKING:
 
 
 class MetaChangeFromDefaultRule(AnsibleLintRule):
+    """meta/main.yml default values should be changed."""
+
     id = "meta-incorrect"
-    shortdesc = "meta/main.yml default values should be changed"
     field_defaults = [
         ("author", "your name"),
         ("description", "your description"),

--- a/src/ansiblelint/rules/meta_no_info.py
+++ b/src/ansiblelint/rules/meta_no_info.py
@@ -55,8 +55,9 @@ def _galaxy_info_errors_itr(
 
 
 class MetaMainHasInfoRule(AnsibleLintRule):
+    """meta/main.yml should contain relevant info."""
+
     id = "meta-no-info"
-    shortdesc = "meta/main.yml should contain relevant info"
     str_info = META_STR_INFO
     info = META_INFO
     description = "meta/main.yml should contain: ``{}``".format(", ".join(info))

--- a/src/ansiblelint/rules/meta_no_tags.py
+++ b/src/ansiblelint/rules/meta_no_tags.py
@@ -15,8 +15,9 @@ if TYPE_CHECKING:
 
 
 class MetaTagValidRule(AnsibleLintRule):
+    """Tags must contain lowercase letters and digits only."""
+
     id = "meta-no-tags"
-    shortdesc = "Tags must contain lowercase letters and digits only"
     description = (
         "Tags must contain lowercase letters and digits only, "
         "and ``galaxy_tags`` is expected to be a list"

--- a/src/ansiblelint/rules/meta_video_links.py
+++ b/src/ansiblelint/rules/meta_video_links.py
@@ -15,8 +15,9 @@ if TYPE_CHECKING:
 
 
 class MetaVideoLinksRule(AnsibleLintRule):
+    """meta/main.yml video_links should be formatted correctly."""
+
     id = "meta-video-links"
-    shortdesc = "meta/main.yml video_links should be formatted correctly"
     description = (
         "Items in ``video_links`` in meta/main.yml should be "
         "dictionaries, and contain only keys ``url`` and ``title``, "

--- a/src/ansiblelint/rules/no_changed_when.py
+++ b/src/ansiblelint/rules/no_changed_when.py
@@ -30,8 +30,9 @@ if TYPE_CHECKING:
 
 
 class CommandHasChangesCheckRule(AnsibleLintRule):
+    """Commands should not change things if nothing needs doing."""
+
     id = "no-changed-when"
-    shortdesc = "Commands should not change things if nothing needs doing"
     description = """
 Tasks should tell Ansible when to return ``changed``, unless the task only reads
 information. To do this, set ``changed_when``, use the ``creates`` or

--- a/src/ansiblelint/rules/no_handler.py
+++ b/src/ansiblelint/rules/no_handler.py
@@ -48,8 +48,9 @@ def _changed_in_when(item: str) -> bool:
 
 
 class UseHandlerRatherThanWhenChangedRule(AnsibleLintRule):
+    """Tasks that run when changed should likely be handlers."""
+
     id = "no-handler"
-    shortdesc = "Tasks that run when changed should likely be handlers"
     description = (
         "If a task has a ``when: result.changed`` setting, it is effectively "
         "acting as a handler. You could use notify and move that task to "

--- a/src/ansiblelint/rules/no_jinja_nesting.py
+++ b/src/ansiblelint/rules/no_jinja_nesting.py
@@ -33,8 +33,9 @@ if TYPE_CHECKING:
 
 
 class NestedJinjaRule(AnsibleLintRule):
+    """Nested jinja pattern."""
+
     id = "no-jinja-nesting"
-    shortdesc = "Nested jinja pattern"
     description = (
         "There should not be any nested jinja pattern. "
         "Example (bad): ``{{ list_one + {{ list_two | max }} }}``, "

--- a/src/ansiblelint/rules/no_jinja_when.py
+++ b/src/ansiblelint/rules/no_jinja_when.py
@@ -12,8 +12,9 @@ if TYPE_CHECKING:
 
 
 class NoFormattingInWhenRule(AnsibleLintRule):
+    """No Jinja2 in when."""
+
     id = "no-jinja-when"
-    shortdesc = "No Jinja2 in when"
     description = (
         "``when`` is a raw Jinja2 expression, remove redundant {{ }} from variable(s)."
     )

--- a/src/ansiblelint/rules/no_log_password.py
+++ b/src/ansiblelint/rules/no_log_password.py
@@ -26,10 +26,9 @@ if TYPE_CHECKING:
 
 
 class NoLogPasswordsRule(AnsibleLintRule):
-    """Describe and test the NoLogPasswordsRule."""
+    """Password should not be logged."."""
 
     id = "no-log-password"
-    shortdesc = "password should not be logged."
     description = (
         "When passing password argument you should have no_log configured "
         "to a non False value to avoid accidental leaking of secrets."

--- a/src/ansiblelint/rules/no_loop_var_prefix.py
+++ b/src/ansiblelint/rules/no_loop_var_prefix.py
@@ -18,7 +18,6 @@ class RoleLoopVarPrefix(AnsibleLintRule):
     """Role loop_var should use configured prefix."""
 
     id = "no-loop-var-prefix"
-    shortdesc = __doc__
     link = (
         "https://docs.ansible.com/ansible/latest/user_guide/"
         "playbooks_loops.html#defining-inner-and-outer-variable-names-with-loop-var"
@@ -38,7 +37,6 @@ Looping inside roles has the risk of clashing with loops from user-playbooks.\
         if not options.loop_var_prefix:
             return results
         self.prefix = options.loop_var_prefix.format(role=toidentifier(file.role))
-        self.shortdesc = f"{self.__class__.shortdesc}: {self.prefix}"
 
         if file.kind not in ("tasks", "handlers"):
             return results

--- a/src/ansiblelint/rules/no_relative_paths.py
+++ b/src/ansiblelint/rules/no_relative_paths.py
@@ -12,8 +12,9 @@ if TYPE_CHECKING:
 
 
 class RoleRelativePath(AnsibleLintRule):
+    """Doesn't need a relative path in role."""
+
     id = "no-relative-paths"
-    shortdesc = "Doesn't need a relative path in role"
     description = (
         "``copy`` and ``template`` do not need to use relative path for ``src``"
     )

--- a/src/ansiblelint/rules/no_same_owner.py
+++ b/src/ansiblelint/rules/no_same_owner.py
@@ -10,9 +10,9 @@ from ansiblelint.utils import LINE_NUMBER_KEY
 
 
 class NoSameOwnerRule(AnsibleLintRule):
+    """Owner should not be kept between different hosts."""
 
     id = "no-same-owner"
-    shortdesc = "Owner should not be kept between different hosts"
     description = """
 Optional rule that highlights dangers of assuming that user/group on the remote
 machines may not exist on ansible controller or vice versa. Owner and group
@@ -133,4 +133,4 @@ if "pytest" in sys.modules:
         results = Runner(test_file, rules=default_rules_collection).run()
         assert len(results) == failures
         for result in results:
-            assert result.message == NoSameOwnerRule.shortdesc
+            assert result.message == NoSameOwnerRule().shortdesc

--- a/src/ansiblelint/rules/no_tabs.py
+++ b/src/ansiblelint/rules/no_tabs.py
@@ -13,8 +13,9 @@ if TYPE_CHECKING:
 
 
 class NoTabsRule(AnsibleLintRule):
+    """Most files should not contain tabs."""
+
     id = "no-tabs"
-    shortdesc = "Most files should not contain tabs"
     description = "Tabs can cause unexpected display issues, use spaces"
     severity = "LOW"
     tags = ["formatting"]
@@ -65,5 +66,5 @@ if "pytest" in sys.modules:
         """Test rule matches."""
         results = rule_runner.run_playbook(RULE_EXAMPLE)
         assert results[0].linenumber == 9
-        assert results[0].message == NoTabsRule.shortdesc
+        assert results[0].message == NoTabsRule().shortdesc
         assert len(results) == 1

--- a/src/ansiblelint/rules/package_latest.py
+++ b/src/ansiblelint/rules/package_latest.py
@@ -29,8 +29,9 @@ if TYPE_CHECKING:
 
 
 class PackageIsNotLatestRule(AnsibleLintRule):
+    """Package installs should not use latest."""
+
     id = "package-latest"
-    shortdesc = "Package installs should not use latest"
     description = (
         "Package installs should use ``state=present`` with or without a version"
     )

--- a/src/ansiblelint/rules/partial_become.py
+++ b/src/ansiblelint/rules/partial_become.py
@@ -86,8 +86,9 @@ def _become_user_without_become(becomeuserabove: bool, data: "odict[str, Any]") 
 
 
 class BecomeUserWithoutBecomeRule(AnsibleLintRule):
+    """become_user requires become to work as expected."""
+
     id = "partial-become"
-    shortdesc = "become_user requires become to work as expected"
     description = "``become_user`` without ``become`` will not actually change user"
     severity = "VERY_HIGH"
     tags = ["unpredictability"]

--- a/src/ansiblelint/rules/playbook_extension.py
+++ b/src/ansiblelint/rules/playbook_extension.py
@@ -10,8 +10,9 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class PlaybookExtension(AnsibleLintRule):
+    """Use ".yml" or ".yaml" playbook extension."""
+
     id = "playbook-extension"
-    shortdesc = 'Use ".yml" or ".yaml" playbook extension'
     description = 'Playbooks should have the ".yml" or ".yaml" extension'
     severity = "MEDIUM"
     tags = ["formatting"]

--- a/src/ansiblelint/rules/risky_file_permissions.py
+++ b/src/ansiblelint/rules/risky_file_permissions.py
@@ -66,8 +66,9 @@ _MODULES_WITH_CREATE: Dict[str, bool] = {
 
 
 class MissingFilePermissionsRule(AnsibleLintRule):
+    """File permissions unset or incorrect."""
+
     id = "risky-file-permissions"
-    shortdesc = "File permissions unset or incorrect"
     description = (
         "Missing or unsupported mode parameter can cause unexpected file "
         "permissions based "

--- a/src/ansiblelint/rules/risky_octal.py
+++ b/src/ansiblelint/rules/risky_octal.py
@@ -29,8 +29,9 @@ if TYPE_CHECKING:
 
 
 class OctalPermissionsRule(AnsibleLintRule):
+    """Octal file permissions must contain leading zero or be a string."""
+
     id = "risky-octal"
-    shortdesc = "Octal file permissions must contain leading zero or be a string"
     description = (
         "Numeric file permissions without leading zero can behave "
         "in unexpected ways. See "

--- a/src/ansiblelint/rules/risky_shell_pipe.py
+++ b/src/ansiblelint/rules/risky_shell_pipe.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
 
 
 class ShellWithoutPipefail(AnsibleLintRule):
+    """Shells that use pipes should set the pipefail option."""
+
     id = "risky-shell-pipe"
-    shortdesc = "Shells that use pipes should set the pipefail option"
     description = (
         "Without the pipefail option set, a shell command that "
         "implements a pipeline can fail and still return 0. If "

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -39,8 +39,10 @@ def _remove_prefix(text: str, prefix: str) -> str:
 
 
 class RoleNames(AnsibleLintRule):
+    # Unable to use f-strings due to flake8 bug with AST parsing
+    """Role name {0} does not match ``^[a-z][a-z0-9_]+$`` pattern."""
+
     id = "role-name"
-    shortdesc = "Role name {0} does not match ``%s`` pattern" % ROLE_NAME_REGEX
     description = (
         "Role names are now limited to contain only lowercase alphanumeric "
         "characters, plus '_' and start with an alpha character. See "
@@ -80,7 +82,7 @@ class RoleNames(AnsibleLintRule):
                 result.append(
                     self.create_matcherror(
                         filename=str(file.path),
-                        message=self.__class__.shortdesc.format(role_name),
+                        message=self.shortdesc.format(role_name),
                     )
                 )
         return result

--- a/src/ansiblelint/rules/syntax_check.py
+++ b/src/ansiblelint/rules/syntax_check.py
@@ -38,10 +38,9 @@ _empty_playbook_re = re.compile(
 
 
 class AnsibleSyntaxCheckRule(AnsibleLintRule):
-    """Ansible syntax check report failure."""
+    """Ansible syntax check failed."""
 
     id = "syntax-check"
-    shortdesc = "Ansible syntax check failed"
     description = DESCRIPTION
     severity = "VERY_HIGH"
     tags = ["core", "unskippable"]

--- a/src/ansiblelint/rules/unnamed_task.py
+++ b/src/ansiblelint/rules/unnamed_task.py
@@ -29,8 +29,9 @@ if TYPE_CHECKING:
 
 
 class TaskHasNameRule(AnsibleLintRule):
+    """All tasks should be named."""
+
     id = "unnamed-task"
-    shortdesc = "All tasks should be named"
     description = (
         "All tasks should have a distinct name for readability "
         "and for ``--start-at-task`` to work"

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -36,10 +36,9 @@ def is_property(k: str) -> bool:
 
 
 class VariableNamingRule(AnsibleLintRule):
+    """All variables should be named using only lowercase and underscores."""
+
     id = "var-naming"
-    base_msg = "All variables should be named using only lowercase and underscores"
-    shortdesc = base_msg
-    description = "All variables should be named using only lowercase and underscores"
     severity = "MEDIUM"
     tags = ["idiom", "experimental"]
     version_added = "v5.0.10"

--- a/src/ansiblelint/rules/var_spacing.py
+++ b/src/ansiblelint/rules/var_spacing.py
@@ -11,9 +11,9 @@ from ansiblelint.yaml_utils import nested_items_path
 
 
 class VariableHasSpacesRule(AnsibleLintRule):
+    """Variables should have spaces before and after: {{ var_name }}."""
+
     id = "var-spacing"
-    base_msg = "Variables should have spaces before and after: "
-    shortdesc = base_msg + " {{ var_name }}"
     description = "Variables should have spaces before and after: ``{{ var_name }}``"
     severity = "LOW"
     tags = ["formatting"]
@@ -29,7 +29,7 @@ class VariableHasSpacesRule(AnsibleLintRule):
             if isinstance(v, str):
                 cleaned = self.exclude_json_re.sub("", v)
                 if bool(self.bracket_regex.search(cleaned)):
-                    return self.base_msg + v
+                    return self.shortdesc.format(var_name=v)
         return False
 
 

--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -25,8 +25,9 @@ you to have a more fine control.
 
 
 class YamllintRule(AnsibleLintRule):
+    """Violations reported by yamllint."""
+
     id = "yaml"
-    shortdesc = "Violations reported by yamllint"
     description = DESCRIPTION
     severity = "VERY_LOW"
     tags = ["formatting", "yaml"]

--- a/test/rules/fixtures/ematcher.py
+++ b/test/rules/fixtures/ematcher.py
@@ -2,11 +2,12 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class EMatcherRule(AnsibleLintRule):
+    """BANNED string found."""
+
     id = "TEST0001"
     description = (
         "This is a test custom rule that looks for lines " + "containing BANNED string"
     )
-    shortdesc = "BANNED string found"
     tags = ["fake", "dummy", "test1"]
 
     def match(self, line: str) -> bool:

--- a/test/rules/fixtures/unset_variable_matcher.py
+++ b/test/rules/fixtures/unset_variable_matcher.py
@@ -2,8 +2,9 @@ from ansiblelint.rules import AnsibleLintRule
 
 
 class UnsetVariableMatcherRule(AnsibleLintRule):
+    """Line contains untemplated variable."""
+
     id = "TEST0002"
-    shortdesc = "Line contains untemplated variable"
     description = (
         "This is a test rule that looks for lines "
         + "post templating that still contain {{"


### PR DESCRIPTION
Simplifies rule by ensuring that we do use the docstring as their short description. This also enables us to address most pylint no-class-docstring excludes.

That is an alternative to another linked PR I made yesterday where I tried to put the description in a docstring, but that proved to cause several problems related to formatting
of docstrings with rst. This approach is simple and without undesired effects.

Related: https://github.com/ansible-community/ansible-lint/pull/1993