### PR TITLE
fix/pylint rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,9 @@ preferred-modules =
 # pylint defaults + f,fh,v,id
 good-names =i,j,k,ex,Run,_,f,fh,v,id,T
 
+# Ignore as being generated:
+ignore-paths=^src/ansiblelint/_version.*$
+
 [MESSAGES CONTROL]
 
 disable =
@@ -17,7 +20,6 @@ disable =
     duplicate-code,
     fixme,
     missing-function-docstring,
-    missing-module-docstring,
     no-member,
     not-callable,
     protected-access,

--- a/src/ansiblelint/_internal/rules.py
+++ b/src/ansiblelint/_internal/rules.py
@@ -1,3 +1,4 @@
+"""Internally used rule classes."""
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 

--- a/src/ansiblelint/rules/command_instead_of_module.py
+++ b/src/ansiblelint/rules/command_instead_of_module.py
@@ -1,3 +1,4 @@
+"""Implementation of command-instead-of-module rule."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/command_instead_of_shell.py
+++ b/src/ansiblelint/rules/command_instead_of_shell.py
@@ -1,3 +1,4 @@
+"""Implementation of command-instead-of-shell rule."""
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/deprecated_bare_vars.py
+++ b/src/ansiblelint/rules/deprecated_bare_vars.py
@@ -1,3 +1,5 @@
+"""Implementation of deprecated-bare-vars rule."""
+
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/deprecated_command_syntax.py
+++ b/src/ansiblelint/rules/deprecated_command_syntax.py
@@ -1,3 +1,4 @@
+"""Implementation of deprecated-command-syntax rule."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/deprecated_local_action.py
+++ b/src/ansiblelint/rules/deprecated_local_action.py
@@ -1,3 +1,4 @@
+"""Implementation for deprecated-local-action rule."""
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 from ansiblelint.rules import AnsibleLintRule

--- a/src/ansiblelint/rules/deprecated_module.py
+++ b/src/ansiblelint/rules/deprecated_module.py
@@ -1,3 +1,4 @@
+"""Implementation of deprecated-module rule."""
 # Copyright (c) 2018, Ansible Project
 
 from typing import TYPE_CHECKING, Any, Dict, Union

--- a/src/ansiblelint/rules/empty_string_compare.py
+++ b/src/ansiblelint/rules/empty_string_compare.py
@@ -1,3 +1,4 @@
+"""Implementation of empty-string-compare rule."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 

--- a/src/ansiblelint/rules/git_latest.py
+++ b/src/ansiblelint/rules/git_latest.py
@@ -1,3 +1,4 @@
+"""Implementation of git-latest rule."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/hg_latest.py
+++ b/src/ansiblelint/rules/hg_latest.py
@@ -1,3 +1,4 @@
+"""Implementation of hg-latest rule."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/inline_env_var.py
+++ b/src/ansiblelint/rules/inline_env_var.py
@@ -1,3 +1,4 @@
+"""Implementation of inside-env-var rule."""
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/literal_compare.py
+++ b/src/ansiblelint/rules/literal_compare.py
@@ -1,3 +1,4 @@
+"""Implementation of the literal-compare rule."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018-2021, Ansible Project
 

--- a/src/ansiblelint/rules/meta_incorrect.py
+++ b/src/ansiblelint/rules/meta_incorrect.py
@@ -1,3 +1,4 @@
+"""Implementation of meta-incorrect rule."""
 # Copyright (c) 2018, Ansible Project
 
 from typing import TYPE_CHECKING, List

--- a/src/ansiblelint/rules/meta_no_info.py
+++ b/src/ansiblelint/rules/meta_no_info.py
@@ -1,3 +1,4 @@
+"""Implementation of meta-no-info rule."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 

--- a/src/ansiblelint/rules/meta_no_tags.py
+++ b/src/ansiblelint/rules/meta_no_tags.py
@@ -1,3 +1,5 @@
+"""Implementation of meta-no-tags rule."""
+
 # Copyright (c) 2018, Ansible Project
 
 import re

--- a/src/ansiblelint/rules/meta_video_links.py
+++ b/src/ansiblelint/rules/meta_video_links.py
@@ -1,3 +1,4 @@
+"""Implementation of meta-video-links rule."""
 # Copyright (c) 2018, Ansible Project
 
 import re

--- a/src/ansiblelint/rules/no_changed_when.py
+++ b/src/ansiblelint/rules/no_changed_when.py
@@ -1,3 +1,4 @@
+"""Implementation of the no-changed-when rule."""
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/no_jinja_nesting.py
+++ b/src/ansiblelint/rules/no_jinja_nesting.py
@@ -1,3 +1,4 @@
+"""Implementation of no-jinja.nesting rule."""
 # -*- coding: utf-8 -*-
 # Author: Adrián Tóth <adtoth@redhat.com>
 #

--- a/src/ansiblelint/rules/no_jinja_when.py
+++ b/src/ansiblelint/rules/no_jinja_when.py
@@ -1,3 +1,4 @@
+"""Implementation of no-jinja-when rule."""
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from ansiblelint.rules import AnsibleLintRule

--- a/src/ansiblelint/rules/no_relative_paths.py
+++ b/src/ansiblelint/rules/no_relative_paths.py
@@ -1,3 +1,4 @@
+"""Implementation of no-relative-paths rule."""
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 

--- a/src/ansiblelint/rules/no_tabs.py
+++ b/src/ansiblelint/rules/no_tabs.py
@@ -1,3 +1,4 @@
+"""Implementation of no-tabs rule."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 import sys

--- a/src/ansiblelint/rules/package_latest.py
+++ b/src/ansiblelint/rules/package_latest.py
@@ -1,3 +1,4 @@
+"""Implementations of the package-latest rule."""
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/partial_become.py
+++ b/src/ansiblelint/rules/partial_become.py
@@ -1,3 +1,4 @@
+"""Implementation of partial-become rule."""
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/playbook_extension.py
+++ b/src/ansiblelint/rules/playbook_extension.py
@@ -1,3 +1,4 @@
+"""Implementation of playbook-extension rule."""
 # Copyright (c) 2016, Tsukinowa Inc. <info@tsukinowa.jp>
 # Copyright (c) 2018, Ansible Project
 

--- a/src/ansiblelint/rules/risky_octal.py
+++ b/src/ansiblelint/rules/risky_octal.py
@@ -1,3 +1,4 @@
+"""Implementation of risky-octal rule."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/risky_shell_pipe.py
+++ b/src/ansiblelint/rules/risky_shell_pipe.py
@@ -1,3 +1,4 @@
+"""Implementation of risky-shell-pipe rule."""
 import re
 from typing import TYPE_CHECKING, Any, Dict, Union
 

--- a/src/ansiblelint/rules/role_name.py
+++ b/src/ansiblelint/rules/role_name.py
@@ -1,3 +1,4 @@
+"""Implementation of role-name rule."""
 # Copyright (c) 2020 Gael Chamoulaud <gchamoul@redhat.com>
 # Copyright (c) 2020 Sorin Sbarnea <ssbarnea@redhat.com>
 #

--- a/src/ansiblelint/rules/unnamed_task.py
+++ b/src/ansiblelint/rules/unnamed_task.py
@@ -1,3 +1,5 @@
+"""Implementation of unnamed-task rule."""
+
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansiblelint/rules/var_naming.py
+++ b/src/ansiblelint/rules/var_naming.py
@@ -1,3 +1,4 @@
+"""Implementation of var-naming rule."""
 import keyword
 import re
 import sys

--- a/src/ansiblelint/rules/var_spacing.py
+++ b/src/ansiblelint/rules/var_spacing.py
@@ -1,3 +1,4 @@
+"""Rule for checking whitespace around variables."""
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 

--- a/src/ansiblelint/rules/yaml.py
+++ b/src/ansiblelint/rules/yaml.py
@@ -1,3 +1,4 @@
+"""Implementation of yaml linting rule (yamllint integration)."""
 import logging
 from typing import TYPE_CHECKING, List
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+"""PyTest fixtures for testing the project."""
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator

--- a/test/rules/fixtures/ematcher.py
+++ b/test/rules/fixtures/ematcher.py
@@ -1,3 +1,4 @@
+"""Custom rule used as fixture."""
 from ansiblelint.rules import AnsibleLintRule
 
 

--- a/test/rules/fixtures/unset_variable_matcher.py
+++ b/test/rules/fixtures/unset_variable_matcher.py
@@ -1,3 +1,4 @@
+"""Custom linting rule used as test fixture."""
 from ansiblelint.rules import AnsibleLintRule
 
 

--- a/test/rules/test_become_user_without_become.py
+++ b/test/rules/test_become_user_without_become.py
@@ -1,3 +1,4 @@
+"""Tests for partial-become rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.partial_become import BecomeUserWithoutBecomeRule
 from ansiblelint.runner import Runner

--- a/test/rules/test_deprecated_local_action.py
+++ b/test/rules/test_deprecated_local_action.py
@@ -1,3 +1,4 @@
+"""Tests for deprecated-local-action rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.deprecated_local_action import TaskNoLocalAction
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_deprecated_module.py
+++ b/test/rules/test_deprecated_module.py
@@ -1,3 +1,4 @@
+"""Tests for deprecated-module rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.deprecated_module import DeprecatedModuleRule
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_inline_env_var.py
+++ b/test/rules/test_inline_env_var.py
@@ -1,3 +1,4 @@
+"""Tests for inline-env-var rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.inline_env_var import EnvVarsInCommandRule
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_line_too_long.py
+++ b/test/rules/test_line_too_long.py
@@ -1,3 +1,4 @@
+"""Tests for line-too-long rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.yaml import YamllintRule
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_literal_compare.py
+++ b/test/rules/test_literal_compare.py
@@ -1,3 +1,4 @@
+"""Tests for literal-compare rule."""
 import pytest
 
 from ansiblelint.rules import RulesCollection

--- a/test/rules/test_meta_change_from_default.py
+++ b/test/rules/test_meta_change_from_default.py
@@ -1,3 +1,4 @@
+"""Tests for meta-incorrect rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.meta_incorrect import MetaChangeFromDefaultRule
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_meta_no_info.py
+++ b/test/rules/test_meta_no_info.py
@@ -1,3 +1,4 @@
+"""Tests for meta-no-info rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.meta_no_info import MetaMainHasInfoRule
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_meta_video_links.py
+++ b/test/rules/test_meta_video_links.py
@@ -1,3 +1,4 @@
+"""Tests for meta-video-links rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.meta_video_links import MetaVideoLinksRule
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_nested_jinja_rule.py
+++ b/test/rules/test_nested_jinja_rule.py
@@ -1,3 +1,4 @@
+"""Tests for nested-jinja rule."""
 # -*- coding: utf-8 -*-
 # Author: Adrián Tóth <adtoth@redhat.com>
 #

--- a/test/rules/test_no_changed_when.py
+++ b/test/rules/test_no_changed_when.py
@@ -1,3 +1,4 @@
+"""Tests for no-change-when rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.no_changed_when import CommandHasChangesCheckRule
 from ansiblelint.runner import Runner

--- a/test/rules/test_no_jinja_when.py
+++ b/test/rules/test_no_jinja_when.py
@@ -1,3 +1,4 @@
+"""Tests for no-jinja-when rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.no_jinja_when import NoFormattingInWhenRule
 from ansiblelint.runner import Runner

--- a/test/rules/test_no_relative_paths.py
+++ b/test/rules/test_no_relative_paths.py
@@ -1,3 +1,4 @@
+"""Tests for no-relative-paths rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.no_relative_paths import RoleRelativePath
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_octal_permissions.py
+++ b/test/rules/test_octal_permissions.py
@@ -1,3 +1,4 @@
+"""Tests for risky-octal rule."""
 import pytest
 
 from ansiblelint.rules import RulesCollection

--- a/test/rules/test_package_latest.py
+++ b/test/rules/test_package_latest.py
@@ -1,3 +1,4 @@
+"""Tests for package-latest rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.package_latest import PackageIsNotLatestRule
 from ansiblelint.runner import Runner

--- a/test/rules/test_risky_shell_pipe.py
+++ b/test/rules/test_risky_shell_pipe.py
@@ -1,3 +1,4 @@
+"""Tests for risky-shell-pile rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.risky_shell_pipe import ShellWithoutPipefail
 from ansiblelint.testing import RunFromText

--- a/test/rules/test_unnamed_task.py
+++ b/test/rules/test_unnamed_task.py
@@ -1,3 +1,4 @@
+"""Tests for unnamed-task rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.unnamed_task import TaskHasNameRule
 from ansiblelint.runner import Runner

--- a/test/rules/test_use_bare_variables.py
+++ b/test/rules/test_use_bare_variables.py
@@ -1,3 +1,4 @@
+"""Tests for deprecated-bare-vars rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.deprecated_bare_vars import UsingBareVariablesIsDeprecatedRule
 from ansiblelint.runner import Runner

--- a/test/rules/test_use_handler_rather_than_when_changed.py
+++ b/test/rules/test_use_handler_rather_than_when_changed.py
@@ -1,3 +1,4 @@
+"""Tests for no-handler rule."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.no_handler import UseHandlerRatherThanWhenChangedRule
 from ansiblelint.testing import RunFromText

--- a/test/test_ansiblelintrule.py
+++ b/test/test_ansiblelintrule.py
@@ -1,3 +1,4 @@
+"""Generic tests for AnsibleLintRule class."""
 from typing import Any, Dict
 
 import pytest

--- a/test/test_cli_role_paths.py
+++ b/test/test_cli_role_paths.py
@@ -1,3 +1,4 @@
+"""Tests related to role paths."""
 import os
 from pathlib import Path
 from typing import Dict

--- a/test/test_commandline_invocations_same_as_config.py
+++ b/test/test_commandline_invocations_same_as_config.py
@@ -1,3 +1,4 @@
+"""Test cli arguments and config."""
 import os
 from pathlib import Path
 from typing import List

--- a/test/test_dependencies_in_meta.py
+++ b/test/test_dependencies_in_meta.py
@@ -1,3 +1,4 @@
+"""Tests about dependencies in meta."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.runner import Runner
 

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -1,3 +1,4 @@
+"""Test for output formatter."""
 # Copyright (c) 2016 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/test_formatter_base.py
+++ b/test/test_formatter_base.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8; -*-
+"""Tests related to base formatter."""
 from pathlib import Path
 from typing import Any, Union
 

--- a/test/test_import_include_role.py
+++ b/test/test_import_include_role.py
@@ -1,3 +1,4 @@
+"""Tests related to role imports."""
 from pathlib import Path
 from typing import List
 

--- a/test/test_import_with_malformed.py
+++ b/test/test_import_with_malformed.py
@@ -1,3 +1,4 @@
+"""Test related to import of invalid files."""
 import pytest
 
 from ansiblelint.file_utils import Lintable

--- a/test/test_include_miss_file_with_role.py
+++ b/test/test_include_miss_file_with_role.py
@@ -1,3 +1,4 @@
+"""Tests related to inclusions."""
 import pytest
 from _pytest.logging import LogCaptureFixture
 

--- a/test/test_lint_rule.py
+++ b/test/test_lint_rule.py
@@ -1,3 +1,4 @@
+"""Tests for lintable."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/test_rule_properties.py
+++ b/test/test_rule_properties.py
@@ -1,3 +1,4 @@
+"""Tests related to rule properties."""
 from ansiblelint.rules import RulesCollection
 
 

--- a/test/test_rules_collection.py
+++ b/test/test_rules_collection.py
@@ -1,3 +1,4 @@
+"""Tests for rule collection class."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,3 +1,4 @@
+"""Tests for runner submodule."""
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/test_skip_import_playbook.py
+++ b/test/test_skip_import_playbook.py
@@ -1,3 +1,4 @@
+"""Test related to skipping import_playbook."""
 from pathlib import Path
 
 import pytest

--- a/test/test_skip_inside_yaml.py
+++ b/test/test_skip_inside_yaml.py
@@ -1,3 +1,4 @@
+"""Tests related to use of inline noqa."""
 import pytest
 
 from ansiblelint.testing import RunFromText

--- a/test/test_skip_playbook_items.py
+++ b/test/test_skip_playbook_items.py
@@ -1,3 +1,4 @@
+"""Tests related to use of noqa inside playbooks."""
 import pytest
 
 from ansiblelint.testing import RunFromText

--- a/test/test_task_includes.py
+++ b/test/test_task_includes.py
@@ -1,3 +1,4 @@
+"""Tests related to task inclusions."""
 import pytest
 
 from ansiblelint.file_utils import Lintable

--- a/test/test_with_skip_tagid.py
+++ b/test/test_with_skip_tagid.py
@@ -1,3 +1,4 @@
+"""Tests related to skip tag id."""
 from ansiblelint.rules import RulesCollection
 from ansiblelint.rules.yaml import YamllintRule
 from ansiblelint.runner import Runner


### PR DESCRIPTION
- Update var-naming to allow jinja2 for names (#1988)
- Avoid accidental skip of tests (#1987)
- Address pylint bad-continuation (#1989)
- Address pylint no-self-use (#1990)
- Address pylint inconsistent-return-statements (#1991)
- Address pylint  unspecified-encoding (#1992)
- Changed rules to use docstring as shortdesc (#1994)
- Minor documentation improvements (#1995)
- Address pylint missing-class-docstring (#1996)
- Address pylint missing-module-docstring
