### PR TITLE
Change invalid config return code to 3

### DIFF
--- a/src/ansiblelint/app.py
+++ b/src/ansiblelint/app.py
@@ -10,6 +10,7 @@ from ansiblelint import formatters
 from ansiblelint._mockings import _perform_mockings
 from ansiblelint.color import console, console_stderr, render_yaml
 from ansiblelint.config import options as default_options
+from ansiblelint.constants import SUCCESS_RC, VIOLATIONS_FOUND_RC
 from ansiblelint.errors import MatchError
 
 if TYPE_CHECKING:
@@ -170,8 +171,8 @@ warn_list:  # or 'skip_list' to silence them completely
             )
 
         if mark_as_success or not failures:
-            return 0
-        return 2
+            return SUCCESS_RC
+        return VIOLATIONS_FOUND_RC
 
 
 def choose_formatter_factory(

--- a/src/ansiblelint/constants.py
+++ b/src/ansiblelint/constants.py
@@ -12,7 +12,9 @@ else:
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), "rules")
 CUSTOM_RULESDIR_ENVVAR = "ANSIBLE_LINT_CUSTOM_RULESDIR"
 
-INVALID_CONFIG_RC = 2
+SUCCESS_RC = 0
+VIOLATIONS_FOUND_RC = 2
+INVALID_CONFIG_RC = 3
 EXIT_CONTROL_C_RC = 130
 
 # Minimal version of Ansible we support for runtime

--- a/test/test_commandline_invocations_same_as_config.py
+++ b/test/test_commandline_invocations_same_as_config.py
@@ -127,8 +127,8 @@ def test_path_from_cli_depend_on_cwd(
     ),
 )
 def test_config_failure(base_arguments: List[str], config_file: str) -> None:
-    """Ensures specific config files produce error code 2."""
-    with pytest.raises(SystemExit, match="^2$"):
+    """Ensures specific config files produce error code 3."""
+    with pytest.raises(SystemExit, match="^3$"):
         cli.get_config(base_arguments + ["-c", config_file])
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -38,6 +38,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from ansiblelint import cli, constants, utils
 from ansiblelint.__main__ import initialize_logger
 from ansiblelint.cli import get_rules_dirs
+from ansiblelint.constants import VIOLATIONS_FOUND_RC
 from ansiblelint.file_utils import Lintable
 from ansiblelint.testing import run_ansible_lint
 
@@ -246,8 +247,7 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     result = subprocess.run(cmd, check=False).returncode
 
     # We de expect to fail on our own repo due to test examples we have
-    # TODO(ssbarnea) replace it with exact return code once we document them
-    assert result != 0
+    assert result == VIOLATIONS_FOUND_RC
 
     out, err = capfd.readouterr()
 


### PR DESCRIPTION
As current tool behavior was to use the same exit code (2) for both
found errors or invalid config, we change the later one to 3, so users
can easily differentiate.