### PR TITLE
Use only ansible-compat cache directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,7 +120,7 @@ repos:
         # empty args needed in order to match mypy cli behavior
         args: [--strict]
         additional_dependencies:
-          - ansible-compat>=2.0.0
+          - ansible-compat>=2.0.1
           - ansible-core
           - enrich
           - flaky
@@ -144,7 +144,7 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies:
-          - ansible-compat>=2.0.0
+          - ansible-compat>=2.0.1
           - ansible-core
           - docutils
           - enrich

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --no-annotate --output-file=docs/requirements.txt --strip-extras docs/requirements.in setup.cfg
 #
 alabaster==0.7.12
-ansible-compat==2.0.0
+ansible-compat==2.0.1
 ansible-core==2.12.2
 ansible-pygments==0.1.1
 attrs==21.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=test --no-annotate --output-file=requirements.txt --strip-extras setup.cfg
 #
-ansible-compat==2.0.0
+ansible-compat==2.0.1
 ansible-core==2.12.2
 astroid==2.9.3
 attrs==21.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ zip_safe = False
 
 # These are required in actual runtime:
 install_requires =
-  ansible-compat>=2.0.0  # GPLv3
+  ansible-compat>=2.0.1  # GPLv3
   ansible-core>=2.12.0  # GPLv3
   enrich>=1.2.6
   packaging

--- a/src/ansiblelint/__main__.py
+++ b/src/ansiblelint/__main__.py
@@ -21,7 +21,6 @@
 """Command line implementation."""
 
 import errno
-import hashlib
 import logging
 import os
 import pathlib
@@ -32,6 +31,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
 from ansible_compat.config import ansible_version
+from ansible_compat.prerun import get_cache_dir
 from enrich.console import should_do_markup
 
 from ansiblelint import cli
@@ -101,12 +101,7 @@ def initialize_options(arguments: Optional[List[str]] = None) -> None:
     options.warn_list = [normalize_tag(tag) for tag in options.warn_list]
 
     options.configured = True
-    # 6 chars of entropy should be enough
-    cache_key = hashlib.sha256(
-        os.path.abspath(options.project_dir).encode()
-    ).hexdigest()[:6]
-    cache_dir = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
-    options.cache_dir = f"{cache_dir}/ansible-lint/{cache_key}"
+    options.cache_dir = get_cache_dir(options.project_dir)
 
 
 def _do_list(rules: "RulesCollection") -> int:


### PR DESCRIPTION
Ensures that we use the same cache_dir as ansible-compat.