### PR TITLE
`--write`: Add `MatchError.yaml_path` for transforms

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 503
+      PYTEST_REQPASS: 546
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/errors.py
+++ b/src/ansiblelint/errors.py
@@ -1,6 +1,6 @@
 """Exceptions and error representations."""
 import functools
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from ansiblelint._internal.rules import BaseRule, RuntimeErrorRule
 from ansiblelint.file_utils import Lintable, normpath
@@ -76,6 +76,8 @@ class MatchError(ValueError):
         self.match_type: Optional[str] = None
         # for task matches, save the normalized task object (useful for transforms)
         self.task: Optional[Dict[str, Any]] = None
+        # path to the problem area, like: [0,"pre_tasks",3] for [0].pre_tasks[3]
+        self.yaml_path: List[Union[int, str]] = []
 
     def __repr__(self) -> str:
         """Return a MatchError instance representation."""

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -10,7 +10,18 @@ from argparse import Namespace
 from collections import defaultdict
 from functools import lru_cache
 from importlib.abc import Loader
-from typing import Any, Dict, Iterator, List, Optional, Set, Union
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Set,
+    Union,
+    cast,
+)
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
@@ -202,7 +213,7 @@ class AnsibleLintRule(BaseRule):
         return matches
 
 
-class TransformMixin:  # pylint: disable=too-few-public-methods
+class TransformMixin:
     """A mixin for AnsibleLintRule to enable transforming files.
 
     If ansible-lint is started with the ``--write`` option, then the ``Transformer``
@@ -230,6 +241,13 @@ class TransformMixin:  # pylint: disable=too-few-public-methods
 
             data[0]["tasks"][0]["when"] = False
 
+        This is easier with the ``seek()`` utility method:
+
+        .. code :: python
+
+            target_task = self.seek(match.yaml_path, data)
+            target_task["when"] = False
+
         For any files that aren't YAML, data is the loaded file's content as a string.
         To edit non-YAML files, save the updated contents update ``lintable.content``:
 
@@ -238,6 +256,36 @@ class TransformMixin:  # pylint: disable=too-few-public-methods
             new_data = self.do_something_to_fix_the_match(data)
             lintable.content = new_data
         """
+
+    @staticmethod
+    def seek(
+        yaml_path: List[Union[int, str]],
+        data: Union[MutableMapping[str, Any], MutableSequence[Any], str],
+    ) -> Any:
+        """Get the element identified by ``yaml_path`` in ``data``.
+
+        Rules that work with YAML need to seek, or descend, into nested YAML data
+        structures to perform the relevant transforms. For example:
+
+        .. code:: python
+
+            def transform(self, match, lintable, data):
+                target_task = self.seek(match.yaml_path, data)
+                # transform target_task
+        """
+        if isinstance(data, str):
+            # can't descend into a string
+            return data
+        target = data
+        for segment in yaml_path:
+            # The cast() calls tell mypy what types we expect.
+            # Essentially this does:
+            #   target = target[segment]
+            if isinstance(segment, str):
+                target = cast(MutableMapping[str, Any], target)[segment]
+            elif isinstance(segment, int):
+                target = cast(MutableSequence[Any], target)[segment]
+        return target
 
 
 def is_valid_rule(rule: Any) -> bool:

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -249,7 +249,7 @@ class TransformMixin:
             target_task["when"] = False
 
         For any files that aren't YAML, data is the loaded file's content as a string.
-        To edit non-YAML files, save the updated contents update ``lintable.content``:
+        To edit non-YAML files, save the updated contents in ``lintable.content``:
 
         .. code:: python
 

--- a/src/ansiblelint/rules/__init__.py
+++ b/src/ansiblelint/rules/__init__.py
@@ -248,7 +248,7 @@ class TransformMixin:
             target_task = self.seek(match.yaml_path, data)
             target_task["when"] = False
 
-        For any files that aren't YAML, data is the loaded file's content as a string.
+        For any files that aren't YAML, ``data`` is the loaded file's content as a string.
         To edit non-YAML files, save the updated contents in ``lintable.content``:
 
         .. code:: python

--- a/test/test_transform_mixin.py
+++ b/test/test_transform_mixin.py
@@ -1,0 +1,128 @@
+"""Tests for TransformMixin."""
+
+from typing import Any, Dict, List, MutableMapping, MutableSequence, Type, Union
+
+import pytest
+
+from ansiblelint.rules import TransformMixin
+
+DUMMY_MAP: Dict[str, Any] = {
+    "foo": "text",
+    "bar": {"some": "text2"},
+    "fruits": ["apple", "orange"],
+    "answer": [{"forty-two": ["life", "universe", "everything"]}],
+}
+DUMMY_LIST: List[Dict[str, Any]] = [
+    {"foo": "text"},
+    {"bar": {"some": "text2"}, "fruits": ["apple", "orange"]},
+    {"answer": [{"forty-two": ["life", "universe", "everything"]}]},
+]
+
+
+@pytest.mark.parametrize(
+    ("yaml_path", "data", "expected_error"),
+    (
+        ([0], DUMMY_MAP, KeyError),
+        (["bar", 0], DUMMY_MAP, KeyError),
+        (["fruits", 100], DUMMY_MAP, IndexError),
+        (["answer", 1], DUMMY_MAP, IndexError),
+        (["answer", 0, 42], DUMMY_MAP, KeyError),
+        (["answer", 0, "42"], DUMMY_MAP, KeyError),
+        ([100], DUMMY_LIST, IndexError),
+        ([0, 0], DUMMY_LIST, KeyError),
+        ([0, "wrong key"], DUMMY_LIST, KeyError),
+        ([1, "bar", "wrong key"], DUMMY_LIST, KeyError),
+        ([1, "fruits", "index should be int"], DUMMY_LIST, TypeError),
+        ([1, "fruits", 100], DUMMY_LIST, IndexError),
+    ),
+)
+def test_seek_with_bad_path(
+    yaml_path: List[Union[int, str]],
+    data: Union[MutableMapping[str, Any], MutableSequence[Any], str],
+    expected_error: Type[Exception],
+) -> None:
+    """Verify that TransformMixin.seek() propagates errors."""
+    with pytest.raises(expected_error):
+        TransformMixin.seek(yaml_path, data)
+
+
+@pytest.mark.parametrize(
+    ("yaml_path", "data", "expected"),
+    (
+        ([], DUMMY_MAP, DUMMY_MAP),
+        (["foo"], DUMMY_MAP, DUMMY_MAP["foo"]),
+        (["bar"], DUMMY_MAP, DUMMY_MAP["bar"]),
+        (["bar", "some"], DUMMY_MAP, DUMMY_MAP["bar"]["some"]),
+        (["fruits"], DUMMY_MAP, DUMMY_MAP["fruits"]),
+        (["fruits", 0], DUMMY_MAP, DUMMY_MAP["fruits"][0]),
+        (["fruits", 1], DUMMY_MAP, DUMMY_MAP["fruits"][1]),
+        (["answer"], DUMMY_MAP, DUMMY_MAP["answer"]),
+        (["answer", 0], DUMMY_MAP, DUMMY_MAP["answer"][0]),
+        (["answer", 0, "forty-two"], DUMMY_MAP, DUMMY_MAP["answer"][0]["forty-two"]),
+        (
+            ["answer", 0, "forty-two", 0],
+            DUMMY_MAP,
+            DUMMY_MAP["answer"][0]["forty-two"][0],
+        ),
+        (
+            ["answer", 0, "forty-two", 1],
+            DUMMY_MAP,
+            DUMMY_MAP["answer"][0]["forty-two"][1],
+        ),
+        (
+            ["answer", 0, "forty-two", 2],
+            DUMMY_MAP,
+            DUMMY_MAP["answer"][0]["forty-two"][2],
+        ),
+        ([], DUMMY_LIST, DUMMY_LIST),
+        ([0], DUMMY_LIST, DUMMY_LIST[0]),
+        ([0, "foo"], DUMMY_LIST, DUMMY_LIST[0]["foo"]),
+        ([1], DUMMY_LIST, DUMMY_LIST[1]),
+        ([1, "bar"], DUMMY_LIST, DUMMY_LIST[1]["bar"]),
+        ([1, "bar", "some"], DUMMY_LIST, DUMMY_LIST[1]["bar"]["some"]),
+        ([1, "fruits"], DUMMY_LIST, DUMMY_LIST[1]["fruits"]),
+        ([1, "fruits", 0], DUMMY_LIST, DUMMY_LIST[1]["fruits"][0]),
+        ([1, "fruits", 1], DUMMY_LIST, DUMMY_LIST[1]["fruits"][1]),
+        ([2], DUMMY_LIST, DUMMY_LIST[2]),
+        ([2, "answer"], DUMMY_LIST, DUMMY_LIST[2]["answer"]),
+        ([2, "answer", 0], DUMMY_LIST, DUMMY_LIST[2]["answer"][0]),
+        (
+            [2, "answer", 0, "forty-two"],
+            DUMMY_LIST,
+            DUMMY_LIST[2]["answer"][0]["forty-two"],
+        ),
+        (
+            [2, "answer", 0, "forty-two", 0],
+            DUMMY_LIST,
+            DUMMY_LIST[2]["answer"][0]["forty-two"][0],
+        ),
+        (
+            [2, "answer", 0, "forty-two", 1],
+            DUMMY_LIST,
+            DUMMY_LIST[2]["answer"][0]["forty-two"][1],
+        ),
+        (
+            [2, "answer", 0, "forty-two", 2],
+            DUMMY_LIST,
+            DUMMY_LIST[2]["answer"][0]["forty-two"][2],
+        ),
+        (
+            [],
+            "this is a string that should be returned as is, ignoring path.",
+            "this is a string that should be returned as is, ignoring path.",
+        ),
+        (
+            [2, "answer", 0, "forty-two", 2],
+            "this is a string that should be returned as is, ignoring path.",
+            "this is a string that should be returned as is, ignoring path.",
+        ),
+    ),
+)
+def test_seek(
+    yaml_path: List[Union[int, str]],
+    data: Union[MutableMapping[str, Any], MutableSequence[Any], str],
+    expected: Any,
+) -> None:
+    """Ensure TransformMixin.seek() retrieves the correct data."""
+    actual = TransformMixin.seek(yaml_path, data)
+    assert actual == expected


### PR DESCRIPTION
Transforms need to know where to edit in the YAML data structures. So, we record the path to that location in `MatchError.yaml_path` and provide a `seek()` utility to descend to that location.
