### PR TITLE
Allow normpath accept empty strings

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
       WSLENV: FORCE_COLOR:PYTEST_REQPASS:TOXENV:TOX_PARALLEL_NO_SPINNER
       # Number of expected test passes, safety measure for accidental skip of
       # tests. Update value if you add/remove tests.
-      PYTEST_REQPASS: 546
+      PYTEST_REQPASS: 548
 
     steps:
       - name: Activate WSL1

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -51,6 +51,9 @@ def normpath(path: Union[str, BasePathLike]) -> str:
     Currently it generates a relative path but in the future we may want to
     make this user configurable.
     """
+    # prevent possible ValueError with relpath(), when input is an empty string
+    if not path:
+        path = "."
     # conversion to string in order to allow receiving non string objects
     relpath = os.path.relpath(str(path))
     path_absolute = os.path.abspath(str(path))

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -25,15 +25,17 @@ from .conftest import cwd
 
 
 @pytest.mark.parametrize(
-    "path",
+    ("path", "expected"),
     (
-        pytest.param(Path("a/b/../"), id="pathlib.Path"),
-        pytest.param("a/b/../", id="str"),
+        pytest.param(Path("a/b/../"), "a", id="pathlib.Path"),
+        pytest.param("a/b/../", "a", id="str"),
+        pytest.param("", ".", id="empty"),
+        pytest.param(".", ".", id="empty"),
     ),
 )
-def test_normpath_with_path_object(path: str) -> None:
+def test_normpath(path: str, expected: str) -> None:
     """Ensure that relative parent dirs are normalized in paths."""
-    assert normpath(path) == "a"
+    assert normpath(path) == expected
 
 
 def test_expand_path_vars(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes bug where calling ansible-lint with "" as an argument, it will
raise an exception. We can assume that empty string is the same as
".", especially as we also allow no arguments which are almost always
treated as current directory too.

Related: https://github.com/ansible/ansible-lint-action/runs/5625194911?check_suite_focus=true